### PR TITLE
feat: field formatter option

### DIFF
--- a/.changeset/field-formatter.md
+++ b/.changeset/field-formatter.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+feat: field formatter option

--- a/apps/docs/pages/docs/api-docs.mdx
+++ b/apps/docs/pages/docs/api-docs.mdx
@@ -71,28 +71,14 @@ export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {
 
 ## `<NextAdmin />` component
 
-`<NextAdmin />` is a React component that contains the entire UI of Next Admin. It can take two types of props:
+`<NextAdmin />` is a React component that contains the entire UI of Next Admin. It can take several props:
 - `AdminComponentProps`, which are passed by the [router function](#nextadminrouter-function) via getServerSideProps
-- CustomUIProps' used to customize the UI of Next Admin
+- `options` used to customize the UI, like field formatters for example
+- `dashboard` used to customize the rendered dashboard
 
 > ⚠️ : Do not override these `AdminComponentProps` props, they are used internally by Next Admin.
 
-
-With the `CustomUIProps` you can customize the dashboard part of Next Admin:
-
-Custom Dashboard:
-
-```tsx
-// components/CustomDashboard.tsx
-const Dashboard = () => {
-    return <div>Custom Dashboard</div>
-}
-
-export default Dashboard;
-```
-
-
-This is an example of using the `NextAdmin` component (`CustomUIProps` are optional):
+This is an example of using the `NextAdmin` component with a custom Dashboard component and options:
 
 ```tsx
 // pages/admin/[[...nextadmin]].tsx
@@ -100,7 +86,21 @@ import Dashboard from "../../components/CustomDashboard";
 
 export default function Admin(props: AdminComponentProps) {
   /* Props are passed from the nextAdminRouter function via getServerSideProps */
-  return <NextAdmin {...props} dashboard={Dashboard}/>;
+  return <NextAdmin {...props} dashboard={Dashboard} options={{
+    model: {
+      user: {
+        list: {
+          fields: {
+            role: {
+              formatter: (user) => {
+                return <strong>{user.role as string}</strong>;
+              },
+            }
+          }
+        }
+      }
+    }
+  }} />;
 }
 ```
 

--- a/apps/example/pages/admin/[[...nextadmin]].tsx
+++ b/apps/example/pages/admin/[[...nextadmin]].tsx
@@ -11,7 +11,21 @@ import {
 import Dashboard from "../../components/Dashboard";
 
 export default function Admin(props: AdminComponentProps) {
-  return <NextAdmin {...props} dashboard={Dashboard} />;
+  return <NextAdmin {...props} dashboard={Dashboard} options={{
+    model: {
+      user: {
+        list: {
+          fields: {
+            role: {
+              formatter: (user) => {
+                return <strong>{user.role as string}</strong>;
+              },
+            }
+          }
+        }
+      }
+    }
+  }} />;
 }
 
 export const getServerSideProps: GetServerSideProps = async ({ req, res }) => {

--- a/packages/next-admin/src/components/Cell.tsx
+++ b/packages/next-admin/src/components/Cell.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ListDataFieldValue, ModelName } from "../types";
+import { ListDataFieldValue } from "../types";
 import { ADMIN_BASE_PATH } from "../config";
 import Link from "next/link";
 import clsx from "clsx";
@@ -10,7 +10,9 @@ type Props = {
 };
 export default function Cell({ cell }: Props) {
   if (cell !== null) {
-    if (typeof cell === "object") {
+    if (React.isValidElement(cell)) {
+      return cell;
+    } else if (typeof cell === "object") {
       if (cell.type === "link") {
         return (
           <Link
@@ -61,6 +63,7 @@ export default function Cell({ cell }: Props) {
         </div>
       );
     }
+
     return <div>{JSON.stringify(cell)}</div>;
   }
   return null;

--- a/packages/next-admin/src/components/List.tsx
+++ b/packages/next-admin/src/components/List.tsx
@@ -1,13 +1,17 @@
-import { useRouter } from "next/compat/router";
-import { ITEMS_PER_PAGE } from "../config";
-import { ChangeEvent, useTransition } from "react";
+import { ColumnDef } from "@tanstack/react-table";
 import debounce from "lodash/debounce";
-import { ListData, ListDataItem, ModelName, SchemaModel } from "../types";
+import { useRouter } from "next/compat/router";
+import { ChangeEvent, useTransition } from "react";
+
+import { ITEMS_PER_PAGE } from "../config";
+import { ListData, ListDataItem, ListFieldsOptions, ModelName } from "../types";
+import Cell from "./Cell";
 import { DataTable } from "./DataTable";
 import ListHeader from "./ListHeader";
-import { ColumnDef } from "@tanstack/react-table";
-import Cell from "./Cell";
+import { AdminComponentOptions } from "./NextAdmin";
+import { Pagination } from "./Pagination";
 import TableHead from "./TableHead";
+import TableRowsIndicator from "./TableRowsIndicator";
 import {
   Select,
   SelectContent,
@@ -15,17 +19,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "./radix/Select";
-import TableRowsIndicator from "./TableRowsIndicator";
-import { Pagination } from "./Pagination";
 
 export type ListProps = {
   resource: ModelName;
   data: ListData<ModelName>;
   total: number;
-  modelSchema: SchemaModel<ModelName>;
+  options?: (Required<AdminComponentOptions<ModelName>>)['model'][ModelName]
 };
 
-function List({ resource, data, total, modelSchema }: ListProps) {
+function List({ resource, data, total, options }: ListProps) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const pageIndex =
@@ -72,7 +74,9 @@ function List({ resource, data, total, modelSchema }: ListProps) {
             );
           },
           cell: ({ row }) => {
-            const cellData = row.original[property];
+            const modelData = row.original;
+            const cellData = options?.list?.fields[property as keyof ListFieldsOptions<ModelName>]?.formatter?.(modelData) ?? modelData[property];
+
             return (
               <Cell cell={cellData} />
             );

--- a/packages/next-admin/src/components/NextAdmin.tsx
+++ b/packages/next-admin/src/components/NextAdmin.tsx
@@ -1,18 +1,35 @@
 import { Dialog, Transition } from "@headlessui/react";
 import { Bars3Icon, HomeIcon, XMarkIcon } from "@heroicons/react/24/outline";
+import { clsx } from "clsx";
 import Head from "next/head";
 import Link from "next/link";
-import React, { Fragment, useState } from "react";
-import { clsx } from "clsx";
+import React, { Fragment, ReactNode, useState } from "react";
 
+import { Prisma } from "@prisma/client";
 import { ADMIN_BASE_PATH } from "../config";
+import { Field, ListData, ListDataItem, Model, ModelName, Schema } from "../types";
 import { getSchemaForResource } from "../utils/jsonSchema";
 import Dashboard from "./Dashboard";
 import Form from "./Form";
 import List from "./List";
-import { Prisma } from "@prisma/client";
-import { ListData, ModelName, Schema } from "../types";
 import Message from "./Message";
+
+export type ListComponentFieldsOptions<T extends ModelName> = {
+  [P in Field<T>]?: {
+    formatter?: (item: ListDataItem<ModelName>) => ReactNode;
+  };
+};
+
+export type AdminComponentOptions<T extends ModelName> = {
+  model?: {
+    [P in T]?: {
+      toString?: (item: Model<P>[number]) => string;
+      list?: {
+        fields: ListComponentFieldsOptions<P>;
+      };
+    };
+  };
+};
 
 export type AdminComponentProps = {
   schema: Schema;
@@ -26,6 +43,7 @@ export type AdminComponentProps = {
   resources?: ModelName[];
   total?: number;
   dmmfSchema: Prisma.DMMF.Field[];
+  options?: AdminComponentOptions<ModelName>;
 };
 
 export type CustomUIProps = {
@@ -33,7 +51,6 @@ export type CustomUIProps = {
 };
 
 // Components
-
 export function NextAdmin({
   data,
   resource,
@@ -44,6 +61,7 @@ export function NextAdmin({
   total,
   dmmfSchema,
   dashboard,
+  options,
 }: AdminComponentProps & CustomUIProps) {
   const modelSchema =
     resource && schema ? getSchemaForResource(schema, resource) : undefined;
@@ -69,7 +87,7 @@ export function NextAdmin({
           resource={resource}
           data={data}
           total={total}
-          modelSchema={modelSchema}
+          options={options?.model && options?.model[resource]}
         />
       );
     }

--- a/packages/next-admin/src/components/inputs/MultiSelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelectWidget.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import DoubleArrow from "../../assets/icons/DoubleArrow";
-import { Selector } from "./Selector";
-import MultiSelectItem from "./MultiSelectItem";
 import useCloseOnOutsideClick from "../../hooks/useCloseOnOutsideClick";
+import MultiSelectItem from "./MultiSelectItem";
+import { Selector } from "./Selector";
 
 const MultiSelectWidget = (props: any) => {
   const { formData, onChange, options, name } = props;

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -1,5 +1,6 @@
 import { Prisma, PrismaClient } from "@prisma/client";
 import { JSONSchema7 } from "json-schema";
+import { ReactNode } from "react";
 
 let prisma: PrismaClient;
 

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -199,6 +199,7 @@ export const findRelationInData = async (
     const dmmfPropertyKind = dmmfProperty.kind;
     const dmmfPropertyRelationFromFields = dmmfProperty.relationFromFields;
     const dmmfPropertyRelationToFields = dmmfProperty.relationToFields;
+    
     if (dmmfPropertyKind === "object") {
       if (
         dmmfPropertyRelationFromFields!.length > 0 &&


### PR DESCRIPTION
Fix https://github.com/premieroctet/next-admin/issues/14

This allow user to specify a formatter for fields 

```
export default function Admin(props: AdminComponentProps) {
  return <NextAdmin {...props} dashboard={Dashboard} options={{
    model: {
      user: {
        list: {
          fields: {
            role: {
              formatter: (user) => {
                return <strong>{user.role as string}</strong>;
              },
            }
          }
        }
      }
    }
  }} />;
}
```

![image](https://github.com/premieroctet/next-admin/assets/686101/e2366814-f568-4ab7-91df-6fe598a665e9)
