### PR TITLE
Fix insensitive search for MySQL provider

### DIFF
--- a/.changeset/sharp-bulldogs-appear.md
+++ b/.changeset/sharp-bulldogs-appear.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Fix insensitive search for MySQL providers

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -27,7 +27,7 @@ export const createWherePredicate = (
           ?.filter((field) => field.kind === "scalar")
           .map((field) => {
             if (field.type === "String") {
-              // @ts-expect-error
+              // @ts-ignore
               const mode = Prisma?.QueryMode ? { mode: Prisma.QueryMode.insensitive } : {};
               return {
                 [field.name]: { contains: search, ...mode },

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -1,7 +1,6 @@
 import { Prisma, PrismaClient } from "@prisma/client";
 import { ITEMS_PER_PAGE } from "../config";
 import {
-  EditOptions,
   Field,
   ListOptions,
   ModelName,
@@ -28,8 +27,10 @@ export const createWherePredicate = (
           ?.filter((field) => field.kind === "scalar")
           .map((field) => {
             if (field.type === "String") {
+              // @ts-expect-error
+              const mode = Prisma?.QueryMode ? { mode: Prisma.QueryMode.insensitive } : {};
               return {
-                [field.name]: { contains: search, mode: "insensitive" },
+                [field.name]: { contains: search, ...mode },
               };
             }
             if (field.type === "Int" && !isNaN(Number(search))) {


### PR DESCRIPTION
**Issue**

#107 

**Change**

- Remove `mode` on search when Prisma don't have `QueryMode` property (e.g MySQL databases)