### PR TITLE
Hide search fields on empty search options

### DIFF
--- a/.changeset/quick-games-tease.md
+++ b/.changeset/quick-games-tease.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Possibility to not display search field on list if search option is an empty array. In case search options are not defined, all scalar fields are concerned

--- a/packages/next-admin/src/components/ListHeader.tsx
+++ b/packages/next-admin/src/components/ListHeader.tsx
@@ -5,15 +5,15 @@ import Link from "next/link";
 import { ChangeEvent, useMemo } from "react";
 import Loader from "../assets/icons/Loader";
 import { useConfig } from "../context/ConfigContext";
+import { useI18n } from "../context/I18nContext";
 import { ModelAction, ModelName } from "../types";
 import ActionsDropdown from "./ActionsDropdown";
 import { buttonVariants } from "./radix/Button";
-import { useI18n } from "../context/I18nContext";
 
 type Props = {
   resource: ModelName;
   isPending: boolean;
-  onSearchChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onSearchChange?: (e: ChangeEvent<HTMLInputElement>) => void;
   search: string;
   actions?: ModelAction[];
   selectedRows: RowSelectionState;
@@ -53,7 +53,7 @@ export default function ListHeader({
   return (
     <div className="flex justify-between items-end">
       <div>
-        <div className="mt-4 flex justify-end items-center gap-2">
+        {onSearchChange && <div className="mt-4 flex justify-end items-center gap-2">
           {isPending ? (
             <Loader className="h-6 w-6 stroke-gray-400 animate-spin" />
           ) : (
@@ -70,7 +70,7 @@ export default function ListHeader({
             className="px-3 py-1.5 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm focus-visible:outline focus-visible:outline-indigo-500 focus-visible:ring focus-visible:ring-indigo-500"
             placeholder={t("list.header.search.placeholder")}
           />
-        </div>
+        </div>}
       </div>
       <div className="flex items-center gap-x-4">
         {!!selectedRowsCount && (

--- a/packages/next-admin/src/utils/props.ts
+++ b/packages/next-admin/src/utils/props.ts
@@ -1,5 +1,6 @@
 "use server";
 import { Prisma, PrismaClient } from "@prisma/client";
+import { cloneDeep } from "lodash";
 import qs from "querystring";
 import {
   ActionParams,
@@ -24,7 +25,6 @@ import {
   transformData,
   transformSchema,
 } from "./server";
-import { cloneDeep } from "lodash";
 
 export type GetPropsFromParamsParams = {
   params?: string[];
@@ -99,6 +99,18 @@ export async function getPropsFromParams({
     );
   }
 
+  const clientOptions: NextAdminOptions = {
+    basePath: options.basePath,
+    model: {
+      [resource as ModelName]: {
+        list: {
+          display: options.model?.[resource as ModelName]?.list?.display,
+          search: options.model?.[resource as ModelName]?.list?.search,
+        },
+      }
+    },
+  }
+
   let defaultProps: AdminComponentProps = {
     resources,
     basePath,
@@ -112,6 +124,7 @@ export async function getPropsFromParams({
     resourcesTitles,
     resourcesIdProperty,
     deleteAction,
+    options: clientOptions,
   };
 
   if (!params) return defaultProps;


### PR DESCRIPTION
**Issue**

#116 

**Change**

- Possibility to not display search field on list if search option is an empty array
- In case search options are not defined, all scalar fields are concerned