### PR TITLE
fix: scheme switch hydration and client rendering

### DIFF
--- a/packages/next-admin/src/components/ColorSchemeSwitch.tsx
+++ b/packages/next-admin/src/components/ColorSchemeSwitch.tsx
@@ -1,0 +1,21 @@
+"use client";
+import { useColorScheme } from "../context/ColorSchemeContext";
+import { useI18n } from "../context/I18nContext";
+
+const ColorSchemeSwitch = () => {
+  const { colorScheme, colorSchemeIcon, toggleColorScheme } = useColorScheme();
+  const { t } = useI18n();
+
+  return (
+    <div
+      onClick={toggleColorScheme}
+      role="button"
+      className="text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color hover:text-nextadmin-menu-emphasis hover:bg-nextadmin-menu-muted dark:hover:bg-dark-nextadmin-menu-muted flex cursor-pointer select-none flex-row items-center gap-5 rounded-lg p-3 text-sm font-medium transition-colors"
+    >
+      {colorSchemeIcon}
+      <span className="min-w-[3.5rem]">{t(`theme.${colorScheme}`)}</span>
+    </div>
+  );
+};
+
+export default ColorSchemeSwitch;

--- a/packages/next-admin/src/components/MainLayout.tsx
+++ b/packages/next-admin/src/components/MainLayout.tsx
@@ -51,6 +51,7 @@ export const MainLayout = ({
               resourcesIcons={resourcesIcons}
               user={user}
               externalLinks={externalLinks}
+              forceColorScheme={options?.forceColorScheme}
             />
             <main className="h-full lg:pl-72">
               {message && (

--- a/packages/next-admin/src/components/Menu.tsx
+++ b/packages/next-admin/src/components/Menu.tsx
@@ -8,16 +8,16 @@ import {
 import { clsx } from "clsx";
 import Link from "next/link";
 import { Fragment, useState } from "react";
+import dynamic from "next/dynamic";
 
 import { Cog6ToothIcon, PowerIcon } from "@heroicons/react/24/solid";
-import { useColorScheme } from "../context/ColorSchemeContext";
 import { useConfig } from "../context/ConfigContext";
-import { useI18n } from "../context/I18nContext";
 import { useRouterInternal } from "../hooks/useRouterInternal";
 import {
   AdminComponentProps,
   ModelIcon,
   ModelName,
+  NextAdminOptions,
   SidebarConfiguration,
 } from "../types";
 import { slugify } from "../utils/tools";
@@ -34,6 +34,10 @@ import {
   DropdownTrigger,
 } from "./radix/Dropdown";
 
+const ColorSchemeSwitch = dynamic(() => import("./ColorSchemeSwitch"), {
+  ssr: false,
+});
+
 export type MenuProps = {
   resource?: ModelName;
   resources?: ModelName[];
@@ -44,6 +48,7 @@ export type MenuProps = {
   user?: AdminComponentProps["user"];
   externalLinks?: AdminComponentProps["externalLinks"];
   title?: string;
+  forceColorScheme?: NextAdminOptions["forceColorScheme"];
 };
 
 export default function Menu({
@@ -56,13 +61,11 @@ export default function Menu({
   user,
   externalLinks,
   title,
+  forceColorScheme,
 }: MenuProps) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const { basePath } = useConfig();
   const { pathname } = useRouterInternal();
-  const { colorScheme, colorSchemeIcon, toggleColorScheme } = useColorScheme();
-  const { t } = useI18n();
-  const { options } = useConfig();
 
   const customPagesNavigation = customPages?.map((page) => ({
     name: page.title,
@@ -274,17 +277,7 @@ export default function Menu({
             </ul>
             <div className="flex flex-col">
               {renderExternalLinks()}
-              {!options?.forceColorScheme && (
-                <div
-                  onClick={toggleColorScheme}
-                  className="text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color hover:text-nextadmin-menu-emphasis hover:bg-nextadmin-menu-muted dark:hover:bg-dark-nextadmin-menu-muted flex cursor-pointer select-none flex-row items-center gap-5 rounded-lg p-3 text-sm font-medium transition-colors"
-                >
-                  {colorSchemeIcon}
-                  <span className="min-w-[3.5rem]">
-                    {t(`theme.${colorScheme}`)}
-                  </span>
-                </div>
-              )}
+              {!forceColorScheme && <ColorSchemeSwitch />}
               {renderUser()}
             </div>
           </nav>

--- a/packages/next-admin/src/context/ColorSchemeContext.tsx
+++ b/packages/next-admin/src/context/ColorSchemeContext.tsx
@@ -1,5 +1,9 @@
 "use client";
-import { MoonIcon, SunIcon } from "@heroicons/react/24/outline";
+import {
+  MoonIcon,
+  SunIcon,
+  ComputerDesktopIcon,
+} from "@heroicons/react/24/outline";
 import {
   ReactNode,
   createContext,
@@ -13,10 +17,12 @@ import { BasicColorScheme, ColorScheme, colorSchemes } from "../types";
 import { colorSchemeScript } from "../utils/colorSchemeScript";
 import { useConfig } from "./ConfigContext";
 
-const basicColorSchemeIcons: Record<BasicColorScheme, JSX.Element> = {
-  light: <SunIcon className="h-4 w-4" />,
-  dark: <MoonIcon className="h-4 w-4" />,
-};
+const basicColorSchemeIcons: Record<BasicColorScheme | "system", JSX.Element> =
+  {
+    light: <SunIcon className="h-4 w-4" />,
+    dark: <MoonIcon className="h-4 w-4" />,
+    system: <ComputerDesktopIcon className="h-4 w-4" />,
+  };
 
 type ColorSchemeContextType = {
   colorScheme: ColorScheme;
@@ -61,9 +67,7 @@ export const ColorSchemeProvider = ({ children }: ProviderProps) => {
   const [colorSchemeIcon, setColorSchemeIcon] = useState<
     JSX.Element | undefined
   >(() => {
-    if (colorScheme !== "system") {
-      return basicColorSchemeIcons[colorScheme];
-    }
+    return basicColorSchemeIcons[colorScheme];
   });
   const [systemPreference, setSystemPreference] = useState<BasicColorScheme>();
 
@@ -71,8 +75,7 @@ export const ColorSchemeProvider = ({ children }: ProviderProps) => {
     document.documentElement.classList.remove("dark", "light");
     const colorSchemeValue: BasicColorScheme | undefined =
       colorScheme === "system" ? systemPreference : colorScheme;
-    colorSchemeValue &&
-      setColorSchemeIcon(basicColorSchemeIcons[colorSchemeValue]);
+    colorSchemeValue && setColorSchemeIcon(basicColorSchemeIcons[colorScheme]);
     colorSchemeValue &&
       document.documentElement.classList.add(colorSchemeValue);
   }, [colorScheme, systemPreference]);


### PR DESCRIPTION
## Title

Fix color scheme switch rendering

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

- Move the color scheme switch rendering on the client side to avoid hydration issues
- Add an icon for the `system` scheme

## Screenshots

![image](https://github.com/premieroctet/next-admin/assets/11079152/1d42483a-c743-4d07-922a-825808242f36)

## Testing

Change the schemes, check that there is no hydration error upon refreshing
