### PR TITLE
feat: add possibility to disable fields

### DIFF
--- a/.changeset/giant-badgers-tickle.md
+++ b/.changeset/giant-badgers-tickle.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+feat: add possibility to disable fields

--- a/apps/docs/pages/docs/api-docs.mdx
+++ b/apps/docs/pages/docs/api-docs.mdx
@@ -291,6 +291,7 @@ For the `edit` property, it can take the following:
 | `optionFormatter`            | only for realtion fields, a function that takes the field values as a parameter and returns a string. Useful to display your record in related list                          |
 | `tooltip`                    | a tooltip content to show for the field                                                                                                                                      |
 | `helperText`                 | a helper text that is displayed underneath the input                                                                                                                         |
+| `disabled`                   | a boolean to indicate that the field is read only                                                                                                                            |
 
 ### `pages`
 
@@ -424,6 +425,7 @@ This is the type of the props that are passed to the custom input component:
 | `onChange`  | a function taking a [ChangeEvent](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event) as a parameter |
 | `readonly`  | boolean indicating if the field is editable or not                                                                          |
 | `rawErrors` | array of strings containing the field errors                                                                                |
+| `disabled`  | boolean indicating if the field is disabled                                                                                 |
 
 ## NextAdmin Context
 

--- a/apps/example/components/DatePicker.tsx
+++ b/apps/example/components/DatePicker.tsx
@@ -5,7 +5,7 @@ import "react-datepicker/dist/react-datepicker.css";
 
 type Props = CustomInputProps;
 
-const DatePicker = ({ value, name, onChange }: Props) => {
+const DatePicker = ({ value, name, onChange, disabled }: Props) => {
   return (
     <>
       <DateTimePicker
@@ -20,6 +20,7 @@ const DatePicker = ({ value, name, onChange }: Props) => {
         dateFormat="dd/MM/yyyy HH:mm"
         timeFormat="HH:mm"
         wrapperClassName="w-full"
+        disabled={disabled}
         className="
         dark:bg-dark-nextadmin-background-subtle dark:ring-dark-nextadmin-border-strong
         text-nextadmin-content-inverted

--- a/packages/next-admin/src/components/Form.tsx
+++ b/packages/next-admin/src/components/Form.tsx
@@ -32,6 +32,7 @@ import { PropertyValidationError } from "../exceptions/ValidationError";
 import { useRouterInternal } from "../hooks/useRouterInternal";
 import {
   AdminComponentProps,
+  EditFieldsOptions,
   Field,
   ModelAction,
   ModelIcon,
@@ -113,7 +114,28 @@ const Form = ({
   icon,
 }: FormProps) => {
   const [validation, setValidation] = useState(validationProp);
-  const { edit, id, ...schemas } = getSchemas(data, schema, dmmfSchema);
+  const disabledFields = options?.edit?.fields
+    ? (Object.entries(options?.edit?.fields)
+        .map(
+          ([name, opts]: [
+            string,
+            EditFieldsOptions<ModelName>[Field<ModelName>],
+          ]) => {
+            if (opts?.disabled) {
+              return name;
+            }
+
+            return undefined;
+          }
+        )
+        .filter(Boolean) as string[])
+    : [];
+  const { edit, id, ...schemas } = getSchemas(
+    data,
+    schema,
+    dmmfSchema,
+    disabledFields
+  );
   const { basePath } = useConfig();
   const { router } = useRouterInternal();
   const { t } = useI18n();
@@ -385,6 +407,7 @@ const Form = ({
             readonly,
             rawErrors,
             name: props.name,
+            disabled: props.disabled,
           });
         }
 
@@ -407,6 +430,7 @@ const Form = ({
               name={props.name}
               value={props.value}
               schema={schema}
+              disabled={props.disabled}
             />
           );
         }

--- a/packages/next-admin/src/components/inputs/ArrayField.tsx
+++ b/packages/next-admin/src/components/inputs/ArrayField.tsx
@@ -1,16 +1,18 @@
 import { FieldProps } from "@rjsf/utils";
 import MultiSelectWidget from "./MultiSelectWidget";
 import { JSONSchema7 } from "json-schema";
+import { Enumeration } from "../../types";
 
 const ArrayField = (props: FieldProps) => {
-  const { schema, formData, onChange, name } = props;
-  const options = (schema.items as JSONSchema7).enum;
+  const { schema, formData, onChange, name, disabled } = props;
+  const options = (schema.items as JSONSchema7).enum as Enumeration[];
   return (
     <MultiSelectWidget
       options={options}
       onChange={onChange}
       formData={formData}
       name={name}
+      disabled={disabled}
     />
   );
 };

--- a/packages/next-admin/src/components/inputs/CheckboxWidget.tsx
+++ b/packages/next-admin/src/components/inputs/CheckboxWidget.tsx
@@ -5,6 +5,7 @@ const CheckboxWidget = ({
   options,
   onChange,
   value,
+  disabled,
   ...props
 }: WidgetProps) => {
   return (
@@ -16,7 +17,11 @@ const CheckboxWidget = ({
           name={props.name}
           className="absolute inset-0 -z-10 h-full w-full opacity-0"
         />
-        <SwitchRoot checked={value} onCheckedChange={onChange}>
+        <SwitchRoot
+          checked={value}
+          onCheckedChange={onChange}
+          disabled={disabled}
+        >
           <SwitchThumb />
         </SwitchRoot>
       </div>

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -108,85 +108,104 @@ const FileWidget = (props: WidgetProps) => {
                 )}
               </a>
               {!!fileName && (
-                <span className="ml-2 text-sm font-medium text-gray-700">
+                <span className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted ml-2 text-sm font-medium">
                   {fileName}
                 </span>
               )}
             </div>
-            <div
-              className={clsx("relative flex items-start", {
-                "mb-5": !!fileName,
-              })}
-            >
-              <div className="flex h-6 items-center">
-                <input
-                  id="delete_file"
-                  type="checkbox"
-                  className="text-nextadmin-primary-600 focus:ring-nextadmin-primary-600 h-4 w-4 rounded border-gray-300"
-                  onChange={onCheckDelete}
-                />
+            {!props.disabled && (
+              <div
+                className={clsx("relative flex items-start", {
+                  "mb-5": !!fileName,
+                })}
+              >
+                <div className="flex h-6 items-center">
+                  <input
+                    id="delete_file"
+                    type="checkbox"
+                    className="h-4 w-4 rounded"
+                    onChange={onCheckDelete}
+                  />
+                </div>
+                <div className="ml-2 text-sm leading-6">
+                  <label
+                    htmlFor="delete_file"
+                    className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted font-medium"
+                  >
+                    {t("form.widgets.file_upload.delete")}
+                  </label>
+                </div>
               </div>
-              <div className="ml-2 text-sm leading-6">
+            )}
+          </div>
+        )}
+        {((props.disabled && !fileInfo) || !props.disabled) && (
+          <div
+            className={clsx(
+              "border-nextadmin-border-default dark:border-dark-nextadmin-border-strong flex w-full justify-center rounded-lg border border-dashed px-6 py-10",
+              {
+                "bg-dark-nextadmin-background-subtle": isDragging,
+                "opacity-50": props.disabled,
+              }
+            )}
+            onDrop={(evt) => {
+              if (!props.disabled) {
+                evt.preventDefault();
+                const files = evt.dataTransfer.files;
+
+                setHasChanged(true);
+                handleFileSelect(files[0]);
+                setIsDragging(false);
+              }
+            }}
+            onDragOver={(evt) => {
+              if (!props.disabled) {
+                evt.preventDefault();
+              }
+            }}
+            onDragEnter={(evt) => {
+              if (!props.disabled) {
+                evt.preventDefault();
+                setIsDragging(true);
+              }
+            }}
+            onDragLeave={(evt) => {
+              if (!props.disabled) {
+                evt.preventDefault();
+                setIsDragging(false);
+              }
+            }}
+          >
+            <div className="text-nextadmin-content-inverted/50 dark:text-dark-nextadmin-content-inverted/50 text-center">
+              <CloudArrowUpIcon className="mx-auto h-8 w-8" />
+              <div className="mt-4 flex text-sm leading-6">
                 <label
-                  htmlFor="delete_file"
-                  className="font-medium text-gray-900"
+                  htmlFor={props.id}
+                  className={clsx(
+                    "text-nextadmin-primary-600 hover:text-nextadmin-primary-500 relative cursor-pointer rounded-md font-semibold focus-visible:outline-none",
+                    {
+                      "cursor-not-allowed": props.disabled,
+                    }
+                  )}
                 >
-                  {t("form.widgets.file_upload.delete")}
+                  <span>{t("form.widgets.file_upload.label")}</span>
+                  <input
+                    type="file"
+                    className="sr-only"
+                    ref={inputRef}
+                    id={props.id}
+                    disabled={props.disabled}
+                    name={isDeleting || hasChanged ? props.name : ""}
+                    onChange={handleFileChange}
+                  />
                 </label>
+                <p className="pl-1">
+                  {t("form.widgets.file_upload.drag_and_drop")}
+                </p>
               </div>
             </div>
           </div>
         )}
-        <div
-          className={clsx(
-            "border-nextadmin-border-default dark:border-dark-nextadmin-border-strong flex w-full justify-center rounded-lg border border-dashed px-6 py-10",
-            {
-              "bg-dark-nextadmin-background-subtle": isDragging,
-            }
-          )}
-          onDrop={(evt) => {
-            evt.preventDefault();
-            const files = evt.dataTransfer.files;
-
-            handleFileSelect(files[0]);
-            setIsDragging(false);
-          }}
-          onDragOver={(evt) => {
-            evt.preventDefault();
-          }}
-          onDragEnter={(evt) => {
-            evt.preventDefault();
-            setIsDragging(true);
-          }}
-          onDragLeave={(evt) => {
-            evt.preventDefault();
-            setIsDragging(false);
-          }}
-        >
-          <div className="text-nextadmin-content-inverted/50 dark:text-dark-nextadmin-content-inverted/50 text-center">
-            <CloudArrowUpIcon className="mx-auto h-8 w-8" />
-            <div className="mt-4 flex text-sm leading-6">
-              <label
-                htmlFor={props.id}
-                className="text-nextadmin-primary-600 hover:text-nextadmin-primary-500 relative cursor-pointer rounded-md font-semibold
-                focus-visible:outline-none"
-              >
-                <span>{t("form.widgets.file_upload.label")}</span>
-                <input
-                  type="file"
-                  className="sr-only"
-                  ref={inputRef}
-                  id={props.id}
-                  name={isDeleting || hasChanged ? props.name : ""}
-                  onChange={handleFileChange}
-                />
-              </label>
-              <p className="pl-1">
-                {t("form.widgets.file_upload.drag_and_drop")}
-              </p>
-            </div>
-          </div>
-        </div>
       </div>
     </div>
   );

--- a/packages/next-admin/src/components/inputs/JsonField.tsx
+++ b/packages/next-admin/src/components/inputs/JsonField.tsx
@@ -6,7 +6,7 @@ import { useColorScheme } from "../../context/ColorSchemeContext";
 
 type Props = CustomInputProps;
 
-const JsonField = ({ value, onChange, name }: Props) => {
+const JsonField = ({ value, onChange, name, disabled }: Props) => {
   const { colorScheme } = useColorScheme();
 
   const defaultValue = useMemo(() => {
@@ -30,6 +30,7 @@ const JsonField = ({ value, onChange, name }: Props) => {
         }}
         options={{
           minimap: { enabled: false },
+          readOnly: disabled,
         }}
         theme={colorScheme === "light" ? "light" : "vs-dark"}
         className="dark:bg-dark-nextadmin-background-subtle dark:ring-dark-nextadmin-border-strong text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted ring-nextadmin-border-default focus:ring-nextadmin-brand-default dark:focus:ring-dark-nextadmin-brand-default block w-full rounded-md border-0 px-2 py-1.5 text-sm shadow-sm ring-1 ring-inset transition-all duration-300 placeholder:text-gray-400 focus:ring-1 focus:ring-inset disabled:cursor-not-allowed disabled:opacity-50 sm:leading-6 [&>div]:border-none"

--- a/packages/next-admin/src/components/inputs/MultiSelectItem.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelectItem.tsx
@@ -1,16 +1,24 @@
 import { XMarkIcon } from "@heroicons/react/24/outline";
 
-const MultiSelectItem = ({ label, onRemoveClick }: any) => {
+type Props = {
+  label: string;
+  onRemoveClick: () => void;
+  deletable?: boolean;
+};
+
+const MultiSelectItem = ({ label, onRemoveClick, deletable = true }: Props) => {
   return (
     <div className="py border-nextadmin-border-default dark:border-dark-nextadmin-border-strong text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted dark:hover:bg-dark-nextadmin-background-muted/50 hover:bg-nextadmin-background-muted flex cursor-pointer items-center justify-center rounded-md border px-2 text-sm">
       {label}
-      <button
-        type="button"
-        className="ml-1 flex-shrink-0 cursor-pointer text-gray-400 hover:text-gray-500"
-        onMouseDown={onRemoveClick}
-      >
-        <XMarkIcon className="h-4 w-4" />
-      </button>
+      {deletable && (
+        <button
+          type="button"
+          className="ml-1 flex-shrink-0 cursor-pointer text-gray-400 hover:text-gray-500"
+          onMouseDown={onRemoveClick}
+        >
+          <XMarkIcon className="h-4 w-4" />
+        </button>
+      )}
     </div>
   );
 };

--- a/packages/next-admin/src/components/inputs/MultiSelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelectWidget.tsx
@@ -5,8 +5,17 @@ import useCloseOnOutsideClick from "../../hooks/useCloseOnOutsideClick";
 import { Enumeration } from "../../types";
 import MultiSelectItem from "./MultiSelectItem";
 import { Selector } from "./Selector";
+import clsx from "clsx";
 
-const MultiSelectWidget = (props: any) => {
+type Props = {
+  options?: Enumeration[];
+  onChange: (data: unknown) => unknown;
+  formData: any;
+  name: string;
+  disabled: boolean;
+};
+
+const MultiSelectWidget = (props: Props) => {
   const formContext = useForm();
   const { formData, onChange, options, name } = props;
   const containerRef = useRef<HTMLDivElement>(null);
@@ -19,7 +28,7 @@ const MultiSelectWidget = (props: any) => {
   const selectedValues = formData?.map((item: any) => item?.value) ?? [];
 
   const optionsLeft = options?.filter(
-    (option: Enumeration) =>
+    (option) =>
       !formData?.find((item: Enumeration) => item.value === option.value)
   );
 
@@ -32,8 +41,19 @@ const MultiSelectWidget = (props: any) => {
           value={JSON.stringify(selectedValues)}
         />
         <div
-          className="dark:bg-dark-nextadmin-background-subtle dark:ring-dark-nextadmin-border-strong text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted dark:border-dark-nextadmin-border-default ring-nextadmin-border-default flex min-h-[38px] w-full cursor-default appearance-none flex-wrap gap-x-1 gap-y-1 rounded-md border-0 border-gray-300 px-2 py-1.5 pr-10 text-sm placeholder-gray-500 shadow-sm ring-1 ring-inset transition-all duration-300 placeholder:text-gray-400 disabled:cursor-not-allowed disabled:opacity-50 sm:leading-6"
-          onClick={() => formContext.toggleOpen(name)}
+          className={clsx(
+            "dark:bg-dark-nextadmin-background-subtle dark:ring-dark-nextadmin-border-strong text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted dark:border-dark-nextadmin-border-default ring-nextadmin-border-default flex min-h-[38px] w-full cursor-default appearance-none flex-wrap gap-x-1 gap-y-1 rounded-md border-0 border-gray-300 px-2 py-1.5 pr-10 text-sm placeholder-gray-500 shadow-sm ring-1 ring-inset transition-all duration-300 placeholder:text-gray-400 sm:leading-6",
+            {
+              "cursor-not-allowed opacity-50 [&_*]:pointer-events-auto [&_*]:cursor-default":
+                props.disabled,
+            }
+          )}
+          onClick={() => {
+            if (!props.disabled) {
+              formContext.toggleOpen(name);
+            }
+          }}
+          aria-disabled={props.disabled}
         >
           {formData?.map(
             (value: any, index: number) =>
@@ -42,13 +62,16 @@ const MultiSelectWidget = (props: any) => {
                   key={index}
                   label={value.label}
                   onRemoveClick={() => onRemoveClick(value.value)}
+                  deletable={!props.disabled}
                 />
               )
           )}
         </div>
-        <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3">
-          <DoubleArrow />
-        </div>
+        {!props.disabled && (
+          <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-3">
+            <DoubleArrow />
+          </div>
+        )}
       </div>
       <Selector
         open={!!formContext.relationState?.[name]?.open!}

--- a/packages/next-admin/src/components/inputs/RichText/RichTextField.tsx
+++ b/packages/next-admin/src/components/inputs/RichText/RichTextField.tsx
@@ -6,6 +6,7 @@ import * as Icons from "../../../assets/icons/RichTextActions";
 import { RichTextFormat } from "../../../types";
 import { Button, EditorContainer, Separator, Toolbar } from "./components";
 import { deserialize, renderElement, renderLeaf, serialize } from "./utils";
+import clsx from "clsx";
 
 type RichTextFieldProps = {
   onChange: ChangeEventHandler<HTMLInputElement>;
@@ -16,9 +17,15 @@ type RichTextFieldProps = {
   schema: {
     format?: string;
   };
+  disabled?: boolean;
 };
 
-const RichTextField = ({ schema, onChange, ...props }: RichTextFieldProps) => {
+const RichTextField = ({
+  schema,
+  onChange,
+  disabled,
+  ...props
+}: RichTextFieldProps) => {
   const { value } = props;
   const format = schema?.format?.split("-")[1] as RichTextFormat;
   const deserializedValue = deserialize(value, format);
@@ -41,63 +48,92 @@ const RichTextField = ({ schema, onChange, ...props }: RichTextFieldProps) => {
       <input type="hidden" name={props.name} value={value} />
       <EditorContainer>
         <Toolbar>
-          <Button format="bold" icon={<Icons.Bold />} title="Bold" />
-          <Button format="italic" icon={<Icons.Italic />} title="Italic" />
+          <Button
+            format="bold"
+            icon={<Icons.Bold />}
+            title="Bold"
+            disabled={disabled}
+          />
+          <Button
+            format="italic"
+            icon={<Icons.Italic />}
+            title="Italic"
+            disabled={disabled}
+          />
           <Button
             format="underline"
             icon={<Icons.Underline />}
             title="Underline"
+            disabled={disabled}
           />
           <Button
             format="strikethrough"
             icon={<Icons.Strikethrough />}
             title="Strikethrough"
+            disabled={disabled}
           />
-          <Button format="code" icon={<Icons.Code />} title="Code" />
+          <Button
+            format="code"
+            icon={<Icons.Code />}
+            title="Code"
+            disabled={disabled}
+          />
           <Separator />
           <Button
             format="blockquote"
             icon={<Icons.Quote />}
             title="Blockquote"
+            disabled={disabled}
           />
           <Button
             format="bulleted-list"
             icon={<Icons.BullettedList />}
             title="Bulleted list"
+            disabled={disabled}
           />
           <Button
             format="numbered-list"
             icon={<Icons.NumberedList />}
             title="Numbered list"
+            disabled={disabled}
           />
           <Separator />
           <Button
             format="heading-one"
             icon={<Icons.Heading level={1} />}
             title="Heading 1"
+            disabled={disabled}
           />
           <Button
             format="heading-two"
             icon={<Icons.Heading level={2} />}
             title="Heading 2"
+            disabled={disabled}
           />
           <Button
             format="heading-three"
             icon={<Icons.Heading level={3} />}
             title="Heading 3"
+            disabled={disabled}
           />
         </Toolbar>
         <Editable
           spellCheck
           renderElement={renderElement}
           renderLeaf={renderLeaf}
-          className="border-nextadmin-border-default dark:border-dark-nextadmin-border-default bg-nextadmin-background-default text-nextadmin-content-inverted
-          ring-nextadmin-border-default
-          focus:ring-nextadmin-brand-default
-          dark:focus:ring-dark-nextadmin-brand-default
-          dark:ring-dark-nextadmin-border-strong
-          dark:text-dark-nextadmin-content-inverted
-          dark:bg-dark-nextadmin-background-subtle min-h-[200px] rounded-b-md p-3 shadow-sm ring-1 focus:ring-2 focus-visible:outline-none"
+          readOnly={disabled}
+          className={clsx(
+            "border-nextadmin-border-default dark:border-dark-nextadmin-border-default bg-nextadmin-background-default text-nextadmin-content-inverted",
+            "ring-nextadmin-border-default",
+            "focus:ring-nextadmin-brand-default",
+            "dark:focus:ring-dark-nextadmin-brand-default",
+            "dark:ring-dark-nextadmin-border-strong",
+            "dark:text-dark-nextadmin-content-inverted",
+            "dark:bg-dark-nextadmin-background-subtle min-h-[200px] rounded-b-md p-3 shadow-sm ring-1 focus:ring-2 focus-visible:outline-none",
+            {
+              "cursor-not-allowed opacity-50": disabled,
+            }
+          )}
           autoFocus
         />
       </EditorContainer>

--- a/packages/next-admin/src/components/inputs/RichText/components.tsx
+++ b/packages/next-admin/src/components/inputs/RichText/components.tsx
@@ -26,6 +26,7 @@ type ButtonProps = PropsWithChildren<
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, format, icon, ...props }, ref) => {
     const editor = useSlate();
+
     let active: boolean;
     let handleMouseDown: (
       event: React.MouseEvent<HTMLButtonElement, MouseEvent>
@@ -60,6 +61,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
             "bg-nextadmin-background-default dark:bg-dark-nextadmin-background-default hover:bg-gray-100 focus:bg-gray-100":
               !active,
           },
+          "disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         onMouseDown={handleMouseDown}

--- a/packages/next-admin/src/components/inputs/SelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/SelectWidget.tsx
@@ -13,7 +13,13 @@ import { Enumeration } from "../../types";
 import { slugify } from "../../utils/tools";
 import { Selector } from "./Selector";
 
-const SelectWidget = ({ options, onChange, value, ...props }: WidgetProps) => {
+const SelectWidget = ({
+  options,
+  onChange,
+  value,
+  disabled,
+  ...props
+}: WidgetProps) => {
   const formContext = useForm();
   const name = props.name;
   options as { enumOptions: Enumeration[] };
@@ -46,9 +52,14 @@ const SelectWidget = ({ options, onChange, value, ...props }: WidgetProps) => {
         <input
           id={props.id}
           readOnly
-          className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted h-full w-full flex-1 cursor-default appearance-none bg-transparent focus:outline-none"
+          className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted h-full w-full flex-1 cursor-default appearance-none bg-transparent focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
           value={value?.label || ""}
-          onMouseDown={() => formContext.toggleOpen(name)}
+          disabled={disabled}
+          onMouseDown={() => {
+            if (!disabled) {
+              formContext.toggleOpen(name);
+            }
+          }}
         />
         <div className="flex space-x-3">
           {hasValue && props.schema.relation && (
@@ -61,17 +72,19 @@ const SelectWidget = ({ options, onChange, value, ...props }: WidgetProps) => {
               <ArrowTopRightOnSquareIcon className="h-5 w-5 cursor-pointer text-gray-400" />
             </Link>
           )}
-          {hasValue && (
+          {hasValue && !disabled && (
             <div className="flex items-center" onClick={() => onChange({})}>
               <XMarkIcon className="h-5 w-5 cursor-pointer text-gray-400" />
             </div>
           )}
-          <div
-            className="flex cursor-pointer items-center"
-            onMouseDown={() => formContext.toggleOpen(name)}
-          >
-            <DoubleArrow />
-          </div>
+          {!disabled && (
+            <div
+              className="flex cursor-pointer items-center"
+              onMouseDown={() => formContext.toggleOpen(name)}
+            >
+              <DoubleArrow />
+            </div>
+          )}
         </div>
       </div>
       <Selector

--- a/packages/next-admin/src/components/radix/Switch.tsx
+++ b/packages/next-admin/src/components/radix/Switch.tsx
@@ -9,7 +9,7 @@ export const SwitchRoot = forwardRef<
   return (
     <Switch.Root
       className={clsx(
-        "group relative inline-flex h-5 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full bg-transparent",
+        "group relative inline-flex h-5 w-10 shrink-0 cursor-pointer items-center justify-center rounded-full bg-transparent data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50",
         className
       )}
       ref={ref}
@@ -33,6 +33,7 @@ export const SwitchThumb = forwardRef<
     <Switch.Thumb
       className={clsx(
         "border-nextadmin-border-default absolute left-0 inline-block h-5 w-5 translate-x-0.5 rounded-full border bg-white shadow ring-0 transition-transform duration-100 will-change-transform data-[state=checked]:translate-x-5",
+        "data-[disabled]:cursor-not-allowed",
         className
       )}
       ref={ref}

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -99,6 +99,7 @@ export type EditFieldsOptions<T extends ModelName> = {
     input?: React.ReactElement;
     helperText?: string;
     tooltip?: string;
+    disabled?: boolean;
   } & (P extends keyof ObjectField<T>
     ? {
         optionFormatter?: (item: ModelFromProperty<T, P>) => string;
@@ -422,6 +423,7 @@ export type CustomInputProps = Partial<{
   onChange: (evt: ChangeEvent<HTMLInputElement>) => void;
   readonly: boolean;
   rawErrors: string[];
+  disabled: boolean;
 }>;
 
 export type TranslationKeys =

--- a/packages/next-admin/src/utils/jsonSchema.ts
+++ b/packages/next-admin/src/utils/jsonSchema.ts
@@ -40,7 +40,8 @@ export function getSchemaForResource(schema: any, resource: string) {
 export function getSchemas(
   data: any,
   schema: any,
-  dmmfSchema: Prisma.DMMF.Field[]
+  dmmfSchema: Prisma.DMMF.Field[],
+  disabledFields?: string[]
 ): Schemas & { edit: boolean; id?: string | number } {
   const uiSchema: UiSchema = {};
   let edit = false;
@@ -59,7 +60,8 @@ export function getSchemas(
         dmmfProperty &&
         ((dmmfProperty.hasDefaultValue &&
           typeof dmmfProperty.default === "object") ||
-          dmmfProperty?.isUpdatedAt)
+          dmmfProperty?.isUpdatedAt ||
+          disabledFields?.includes(dmmfProperty.name))
       ) {
         edit
           ? (uiSchema[property] = {


### PR DESCRIPTION
## Title

Add the possibility to disable some fields for a model

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Add a `disabled` property in the fields edit options for a model. This would impact the UI of the field, giving it an opacity of 50% and making it not editable.

For custom inputs, a `disabled` prop is passed.

## Screenshots

Example on the Post model with the `title`, `content` and `published` fields disabled

![image](https://github.com/premieroctet/next-admin/assets/11079152/69c313ca-b963-40a9-8166-12159fcf0929)

Example with the `author` field disabled

![image](https://github.com/premieroctet/next-admin/assets/11079152/cef0ccad-0f87-4b41-b340-d2f2d19a51a0)

The interactions that don't have impact on the content of the form are still possible, for example here we still can go to the author's edit page.
