### PR TITLE
Filter options with selected options dropdown

### DIFF
--- a/.changeset/tricky-days-add.md
+++ b/.changeset/tricky-days-add.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Fix dropdown - filter with non-selected value only (#236)

--- a/packages/next-admin/src/components/inputs/ArrayField.tsx
+++ b/packages/next-admin/src/components/inputs/ArrayField.tsx
@@ -1,14 +1,10 @@
 import { FieldProps } from "@rjsf/utils";
 import MultiSelectWidget from "./MultiSelectWidget";
-import { JSONSchema7 } from "json-schema";
-import { Enumeration } from "../../types";
 
 const ArrayField = (props: FieldProps) => {
-  const { schema, formData, onChange, name, disabled } = props;
-  const options = (schema.items as JSONSchema7).enum as Enumeration[];
+  const { formData, onChange, name, disabled } = props;
   return (
     <MultiSelectWidget
-      options={options}
       onChange={onChange}
       formData={formData}
       name={name}

--- a/packages/next-admin/src/components/inputs/MultiSelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelectWidget.tsx
@@ -8,7 +8,6 @@ import { Selector } from "./Selector";
 import clsx from "clsx";
 
 type Props = {
-  options?: Enumeration[];
   onChange: (data: unknown) => unknown;
   formData: any;
   name: string;
@@ -17,7 +16,7 @@ type Props = {
 
 const MultiSelectWidget = (props: Props) => {
   const formContext = useForm();
-  const { formData, onChange, options, name } = props;
+  const { formData, onChange, name } = props;
   const containerRef = useRef<HTMLDivElement>(null);
   useCloseOnOutsideClick(containerRef, () => formContext.setOpen(false, name));
 

--- a/packages/next-admin/src/components/inputs/MultiSelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelectWidget.tsx
@@ -18,11 +18,6 @@ const MultiSelectWidget = (props: any) => {
 
   const selectedValues = formData?.map((item: any) => item?.value) ?? [];
 
-  const optionsLeft = options?.filter(
-    (option: Enumeration) =>
-      !formData?.find((item: Enumeration) => item.value === option.value)
-  );
-
   return (
     <div className="relative" ref={containerRef}>
       <div className="relative">
@@ -53,10 +48,10 @@ const MultiSelectWidget = (props: any) => {
       <Selector
         open={!!formContext.relationState?.[name]?.open!}
         name={name}
-        options={optionsLeft?.length ? optionsLeft : undefined}
         onChange={(option: Enumeration) => {
           onChange([...(formData || []), option]);
         }}
+        selectedOptions={selectedValues}
       />
     </div>
   );

--- a/packages/next-admin/src/components/inputs/SelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/SelectWidget.tsx
@@ -79,6 +79,7 @@ const SelectWidget = ({ options, onChange, value, ...props }: WidgetProps) => {
         options={enumOptions?.length ? enumOptions : undefined}
         name={props.name}
         onChange={handleChange}
+        selectedOptions={hasValue ? [value?.value] : []}
       />
     </div>
   );


### PR DESCRIPTION
# Pull Request Template

## Title

Improve dropdown SelectWIdget and MultiselectWidget

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#236

## Description

- Filter all fetched options in dropdown and keep only those that are not already selected
- Use `intersectionObserver `to detect last row is reached and fetch next page data

## Impact

No impact
