### PR TITLE
fix: formatter on boolean fields

### DIFF
--- a/.changeset/new-needles-sort.md
+++ b/.changeset/new-needles-sort.md
@@ -2,4 +2,4 @@
 "@premieroctet/next-admin": patch
 ---
 
-(fix): formatter on boolean fields (#249)
+fix: formatter on boolean fields (#249)

--- a/.changeset/new-needles-sort.md
+++ b/.changeset/new-needles-sort.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+(fix): formatter on boolean fields (#249)

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -126,6 +126,11 @@ export const options: NextAdminOptions = {
               return <strong>{author.name}</strong>;
             },
           },
+          published: {
+            formatter: (value: boolean) => {
+              return value ? "Published" : "Unpublished";
+            },
+          },
         },
       },
       edit: {

--- a/apps/example/pageRouterOptions.tsx
+++ b/apps/example/pageRouterOptions.tsx
@@ -102,6 +102,11 @@ export const options: NextAdminOptions = {
               return <strong>{author.name}</strong>;
             },
           },
+          published: {
+            formatter: (value: boolean) => {
+              return value ? "Published" : "Unpublished";
+            },
+          },
         },
       },
       edit: {

--- a/packages/next-admin/src/components/Cell.tsx
+++ b/packages/next-admin/src/components/Cell.tsx
@@ -28,7 +28,7 @@ export default function Cell({ cell, formatter, copyable }: Props) {
       return cellValue;
     } else if (typeof cell === "object" && !isReactNode(cellValue)) {
       if (formatter) {
-        cellValue = formatter(cellValue);
+        cellValue = formatter(cell?.value);
       }
 
       if (cell.type === "link") {

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -235,7 +235,7 @@ export const getMappedDataList = async ({
 
   data.forEach((item, index) => {
     Object.keys(item).forEach((key) => {
-      let itemValue;
+      let itemValue = null;
       const model = capitalize(key) as ModelName;
       const idProperty = getModelIdProperty(model);
       if (typeof item[key] === "object" && item[key] !== null) {
@@ -268,7 +268,7 @@ export const getMappedDataList = async ({
         appDir &&
         key in listFields &&
         listFields[key as keyof typeof listFields]?.formatter &&
-        !!itemValue
+        itemValue !== null
       ) {
         item[key].__nextadmin_formatted = listFields[
           key as keyof typeof listFields


### PR DESCRIPTION
## Title

Fix formatting for boolean fields

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#249 

## Description

There was an issue in the formatter where the boolean fields did not pass a condition because of an incorrect check. The issue was also present on page router.

## Testing

Add a formatter for the `published` field of the `Post` model in the example app. Check and uncheck the toggle in the edit form. The value should be formatted as `Published` or `Unpublished` on the list.
