### PR TITLE
fix: sort many-to-one relationship in list

### DIFF
--- a/.changeset/green-apples-eat.md
+++ b/.changeset/green-apples-eat.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: sort many-to-one relationship in list (#248)

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -422,7 +422,10 @@ export type Body<F> = {
 };
 
 export type Order<M extends ModelName> = {
-  [P in Field<M>]?: Prisma.SortOrder | { _count: Prisma.SortOrder };
+  [P in Field<M>]?:
+    | Prisma.SortOrder
+    | { _count: Prisma.SortOrder }
+    | { [key: string]: Prisma.SortOrder };
 };
 
 export type Select<M extends ModelName> = {

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -96,13 +96,19 @@ export const preparePrismaListRequest = <M extends ModelName>(
   if (orderValue in Prisma.SortOrder) {
     if (sortParam in Prisma[`${capitalize(resource)}ScalarFieldEnum`]) {
       orderBy[sortParam] = orderValue;
-    } else if (
-      modelFieldSortParam?.kind === "object" &&
-      modelFieldSortParam.isList
-    ) {
-      orderBy[modelFieldSortParam.name as Field<M>] = {
-        _count: orderValue,
-      };
+    } else if (modelFieldSortParam?.kind === "object") {
+      if (modelFieldSortParam.isList) {
+        orderBy[modelFieldSortParam.name as Field<M>] = {
+          _count: orderValue,
+        };
+      } else {
+        const resourceIdProperty = getModelIdProperty(
+          modelFieldSortParam.type as ModelName
+        );
+        orderBy[modelFieldSortParam.name as Field<M>] = {
+          [resourceIdProperty]: orderValue,
+        };
+      }
     }
   }
 


### PR DESCRIPTION
## Title

Fix sort for many-to-one relationships in list

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#248 

## Description

We only handled sorting on many-to-many or one-to-many relationships. We now have a condition to set the correct orderBy field in the prisma request depending on the relationship.
