### PR TITLE
feat: add deletion message customization

### DIFF
--- a/.changeset/shaggy-pumpkins-help.md
+++ b/.changeset/shaggy-pumpkins-help.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+feat: add deletion message customization (#254)

--- a/apps/docs/pages/docs/i18n.mdx
+++ b/apps/docs/pages/docs/i18n.mdx
@@ -19,6 +19,7 @@ The following keys are accepted:
 | list.empty.caption                     | The caption displayed when there is no row in the list                                        | Get started by creating a new \{\{resource\}\}            |
 | form.button.save.label                 | The text displayed in the form submit button                                                  | Submit                                                    |
 | form.button.delete.label               | The text displayed in the form delete button                                                  | Delete                                                    |
+| form.delete.alert                      | The text displayed on the alert when the delete button is clicked                             | Are you sure you want to delete this?                     |
 | form.widgets.file_upload.label         | The text displayed in file upload widget to select a file                                     | Choose a file                                             |
 | form.widgets.file_upload.drag_and_drop | The text displayed in file upload widget to indicate a drag & drop is possible                | or drag and drop                                          |
 | form.widgets.file_upload.delete        | The text displayed in file upload widget to delete the current file                           | Delete                                                    |

--- a/apps/docs/pages/docs/i18n.mdx
+++ b/apps/docs/pages/docs/i18n.mdx
@@ -4,25 +4,28 @@ Next Admin supports i18n with the `translations` prop of the `NextAdmin` compone
 
 The following keys are accepted:
 
-| Name                                   | Description                                                                                   | Default value                                  |
-| -------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------- |
-| list.header.add.label                  | The "Add" button in the list header                                                           | Add                                            |
-| list.header.search.placeholder         | The placeholder used in the search input                                                      | Search                                         |
-| list.footer.indicator.showing          | The "Showing from" text in the list indicator, e.g: <u>Showing from</u> 1 to 10 of 25         | Showing from                                   |
-| list.footer.indicator.to               | The "to" text in the list indicator, e.g: Showing from 1 <u>to</u> 10 of 25                   | to                                             |
-| list.footer.indicator.of               | The "of" text in the list indicator, e.g: Showing from 1 to 10 <u>of</u> 25                   | of                                             |
-| list.row.actions.delete.label          | The text in the delete button displayed at the end of each row                                | Delete                                         |
-| list.empty.label                       | The text displayed when there is no row in the list                                           | No \{\{resource\}\} found                      |
-| list.empty.caption                     | The caption displayed when there is no row in the list                                        | Get started by creating a new \{\{resource\}\} |
-| form.button.save.label                 | The text displayed in the form submit button                                                  | Submit                                         |
-| form.button.delete.label               | The text displayed in the form delete button                                                  | Delete                                         |
-| form.widgets.file_upload.label         | The text displayed in file upload widget to select a file                                     | Choose a file                                  |
-| form.widgets.file_upload.drag_and_drop | The text displayed in file upload widget to indicate a drag & drop is possible                | or drag and drop                               |
-| form.widgets.file_upload.delete        | The text displayed in file upload widget to delete the current file                           | Delete                                         |
-| form.widgets.multiselect.select        | The text displayed in the multiselect widget in list display mode to toggle the select dialog | Select items                                         |
-| actions.label                          | The text displayed in the dropdown button for the actions list                                | Action                                         |
-| actions.delete.label                   | The text displayed for the default delete action in the actions dropdown                      | Delete                                         |
-| selector.loading                       | The text displayed in the selector widget while loading the options                           | Loading...                                     |
+| Name                                   | Description                                                                                   | Default value                                             |
+| -------------------------------------- | --------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| list.header.add.label                  | The "Add" button in the list header                                                           | Add                                                       |
+| list.header.search.placeholder         | The placeholder used in the search input                                                      | Search                                                    |
+| list.footer.indicator.showing          | The "Showing from" text in the list indicator, e.g: <u>Showing from</u> 1 to 10 of 25         | Showing from                                              |
+| list.footer.indicator.to               | The "to" text in the list indicator, e.g: Showing from 1 <u>to</u> 10 of 25                   | to                                                        |
+| list.footer.indicator.of               | The "of" text in the list indicator, e.g: Showing from 1 to 10 <u>of</u> 25                   | of                                                        |
+| list.row.actions.delete.label          | The text in the delete button displayed at the end of each row                                | Delete                                                    |
+| list.row.actions.delete.alert          | The text in the native alert when the delete action is called in the list                     | Are you sure you want to delete \{\{count\}\} element(s)? |
+| list.row.actions.delete.success        | The text appearing after a successful deletion from the list                                  | Deleted successfully                                      |
+| list.row.actions.delete.error          | The text appearing after an error during the deletion from the list                           | An error occured while deleting                           |
+| list.empty.label                       | The text displayed when there is no row in the list                                           | No \{\{resource\}\} found                                 |
+| list.empty.caption                     | The caption displayed when there is no row in the list                                        | Get started by creating a new \{\{resource\}\}            |
+| form.button.save.label                 | The text displayed in the form submit button                                                  | Submit                                                    |
+| form.button.delete.label               | The text displayed in the form delete button                                                  | Delete                                                    |
+| form.widgets.file_upload.label         | The text displayed in file upload widget to select a file                                     | Choose a file                                             |
+| form.widgets.file_upload.drag_and_drop | The text displayed in file upload widget to indicate a drag & drop is possible                | or drag and drop                                          |
+| form.widgets.file_upload.delete        | The text displayed in file upload widget to delete the current file                           | Delete                                                    |
+| form.widgets.multiselect.select        | The text displayed in the multiselect widget in list display mode to toggle the select dialog | Select items                                              |
+| actions.label                          | The text displayed in the dropdown button for the actions list                                | Action                                                    |
+| actions.delete.label                   | The text displayed for the default delete action in the actions dropdown                      | Delete                                                    |
+| selector.loading                       | The text displayed in the selector widget while loading the options                           | Loading...                                                |
 
 There is two ways to translate these default keys, provide a function named `getMessages` inside the options or provide `translations` props to `NextAdmin` component.
 

--- a/packages/next-admin/src/components/Form.tsx
+++ b/packages/next-admin/src/components/Form.tsx
@@ -209,7 +209,7 @@ const Form = ({
               value="delete"
               tabIndex={-1}
               onClick={(e) => {
-                if (!confirm("Are you sure to delete this ?")) {
+                if (!confirm(t("form.delete.alert"))) {
                   e.preventDefault();
                 }
               }}

--- a/packages/next-admin/src/hooks/useDeleteAction.ts
+++ b/packages/next-admin/src/hooks/useDeleteAction.ts
@@ -1,4 +1,5 @@
 import { useConfig } from "../context/ConfigContext";
+import { useI18n } from "../context/I18nContext";
 import { ModelAction, ModelName } from "../types";
 import { slugify } from "../utils/tools";
 import { useRouterInternal } from "./useRouterInternal";
@@ -9,14 +10,11 @@ export const useDeleteAction = (
 ) => {
   const { isAppDir, basePath } = useConfig();
   const { router } = useRouterInternal();
+  const { t } = useI18n();
 
   const deleteItems = async (ids: string[] | number[]) => {
     if (
-      window.confirm(
-        `Are you sure you want to delete ${ids.length} row${
-          ids.length === 1 ? "" : "s"
-        }?`
-      )
+      window.confirm(t("list.row.actions.delete.alert", { count: ids.length }))
     ) {
       try {
         if (isAppDir) {
@@ -35,7 +33,7 @@ export const useDeleteAction = (
           {
             message: JSON.stringify({
               type: "success",
-              content: "Deleted successfully",
+              content: t("list.row.actions.delete.success"),
             }),
           },
           true
@@ -43,7 +41,7 @@ export const useDeleteAction = (
       } catch {
         router.setQuery(
           {
-            error: "An error occured while deleting",
+            error: t("list.row.actions.delete.error"),
           },
           true
         );

--- a/packages/next-admin/src/i18n.ts
+++ b/packages/next-admin/src/i18n.ts
@@ -17,6 +17,10 @@ export const defaultTranslations: Translations = {
   "list.header.search.result": "{{count}} items",
   "list.header.search.result_filtered": "{{count}} filtered items",
   "list.row.actions.delete.label": "Delete",
+  "list.row.actions.delete.alert":
+    "Are you sure you want to delete {{count}} row(s)?",
+  "list.row.actions.delete.success": "Deleted successfully",
+  "list.row.actions.delete.error": "An error occured while deleting",
   "form.widgets.file_upload.label": "Choose a file",
   "form.widgets.file_upload.drag_and_drop": "or drag and drop",
   "form.widgets.file_upload.delete": "Delete",

--- a/packages/next-admin/src/i18n.ts
+++ b/packages/next-admin/src/i18n.ts
@@ -4,6 +4,7 @@ export const defaultTranslations: Translations = {
   "actions.delete.label": "Delete",
   "actions.label": "Action",
   "form.button.delete.label": "Delete",
+  "form.delete.alert": "Are you sure to delete this?",
   "form.button.save.label": "Save",
   "form.button.save_edit.label": "Save and continue editing",
   "list.empty.label": "No {{resource}} found",


### PR DESCRIPTION
## Title

Add deletion message customization, with i18n compat

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#254 

## Description

Add keys to the i18n messages and add them in the `useDeleteAction` hook
