### PR TITLE
feat: add field selection for relationship sort

### DIFF
--- a/.changeset/flat-knives-train.md
+++ b/.changeset/flat-knives-train.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+feat: add field selection for relationship sort (#258)

--- a/apps/docs/pages/docs/api-docs.mdx
+++ b/apps/docs/pages/docs/api-docs.mdx
@@ -277,6 +277,7 @@ For the `list` property, it can take the following:
 | Name        | Description                                                                                                                                                                |
 | ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `formatter` | a function that takes the field value as a parameter, and that return a JSX node. It also accepts a second argument which is the [`NextAdmin` context](#nextadmin-context) |
+| `sortBy`    | available only on many-to-one models. The name of a field of the related model to apply the sort on. Defaults to the id field of the related model.                        |
 
 For the `edit` property, it can take the following:
 

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -103,11 +103,18 @@ export const preparePrismaListRequest = <M extends ModelName>(
           _count: orderValue,
         };
       } else {
-        const resourceIdProperty = getModelIdProperty(
-          modelFieldSortParam.type as ModelName
-        );
+        const modelFieldSortProperty =
+          options?.model?.[resource]?.list?.fields?.[
+            modelFieldSortParam.name as Field<M>
+            // @ts-expect-error
+          ]?.sortBy;
+
+        const resourceSortByField =
+          modelFieldSortProperty ??
+          getModelIdProperty(modelFieldSortParam.type as ModelName);
+
         orderBy[modelFieldSortParam.name as Field<M>] = {
-          [resourceIdProperty]: orderValue,
+          [resourceSortByField]: orderValue,
         };
       }
     }


### PR DESCRIPTION
## Title

Add the possibility to select the field that is used to sort on relationship

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#258 

## Description

Add a `sortBy` property to a field in the list field options, which corresponds to a property of the related model.
