### PR TITLE
Add required options on edit fields

### DIFF
--- a/.changeset/poor-planes-repeat.md
+++ b/.changeset/poor-planes-repeat.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+Add possibly to apply required HTML validation on fields (#257)

--- a/apps/docs/pages/docs/api-docs.mdx
+++ b/apps/docs/pages/docs/api-docs.mdx
@@ -282,7 +282,7 @@ For the `list` property, it can take the following:
 For the `edit` property, it can take the following:
 
 | Name                         | Description                                                                                                                                                                  |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
 | `validate`                   | a function that takes the field value as a parameter, and that returns a boolean                                                                                             |
 | `format`                     | a string defining an OpenAPI field format, overriding the one set in the generator. An extra `file` format can be used to be able to have a file input                       |
 | `input`                      | a React Element that should receive [CustomInputProps](#custominputprops). For App Router, this element must be a client component.                                          |
@@ -295,6 +295,7 @@ For the `edit` property, it can take the following:
 | `helperText`                 | a helper text that is displayed underneath the input                                                                                                                         |
 | `disabled`                   | a boolean to indicate that the field is read only                                                                                                                            |
 | `display`                    | only for relation fields, indicate which display format to use between `list`, `table` or `select`. Default `select`                                                         |
+| `required`                   | a true value to force a field to be required in the form, note that if the field is required by the Prisma schema, you cannot set `required` to false                        | undefined |
 
 ##### `filters` property
 

--- a/apps/example/app/[locale]/admin/[[...nextadmin]]/page.tsx
+++ b/apps/example/app/[locale]/admin/[[...nextadmin]]/page.tsx
@@ -17,8 +17,8 @@ export const viewport: Viewport = {
 };
 
 export const metadata: Metadata = {
-  icons: "/favicon.ico"
-}
+  icons: "/favicon.ico",
+};
 
 export default async function AdminPage({
   params,

--- a/apps/example/e2e/001-crud.spec.ts
+++ b/apps/example/e2e/001-crud.spec.ts
@@ -1,5 +1,5 @@
 import { test } from "@playwright/test";
-import { createItem, deleteItem, readItem, updateItem } from "./utils";
+import { createItem, dataTest, deleteItem, readItem, updateItem } from "./utils";
 
 export const models = ["User", "Post", "Category"] as const;
 
@@ -26,11 +26,22 @@ models.forEach((model) => {
 });
 
 test.describe("user validation", () => {
-  test(`user create error`, async ({ page }) => {
+  test(`user create server error`, async ({ page }) => {
     await page.goto(`${process.env.BASE_URL}/User/new`);
+    await page.fill('input[id="name"]', dataTest.User.name);
     await page.fill('input[id="email"]', "invalidemail");
     await page.click('button:has-text("Save and continue editing")');
     await page.waitForURL(`${process.env.BASE_URL}/User/new`);
     await test.expect(page.getByText("Invalid email")).toBeVisible();
+  });
+
+  test(`user create client error`, async ({ page }) => {
+    await page.goto(`${process.env.BASE_URL}/User/new`);
+    const nameRequired = page.locator('input[id="name"][required]');
+    await page.fill('input[id="email"]', dataTest.User.email);
+    const validationMessage = await nameRequired.evaluate(
+      (element) => (element as HTMLInputElement).validationMessage
+    );
+    test.expect(validationMessage).not.toBeNull();
   });
 });

--- a/apps/example/e2e/001-crud.spec.ts
+++ b/apps/example/e2e/001-crud.spec.ts
@@ -1,5 +1,11 @@
 import { test } from "@playwright/test";
-import { createItem, dataTest, deleteItem, readItem, updateItem } from "./utils";
+import {
+  createItem,
+  dataTest,
+  deleteItem,
+  readItem,
+  updateItem,
+} from "./utils";
 
 export const models = ["User", "Post", "Category"] as const;
 

--- a/apps/example/e2e/001-crud.spec.ts
+++ b/apps/example/e2e/001-crud.spec.ts
@@ -44,7 +44,6 @@ test.describe("user validation", () => {
   test(`user create client error`, async ({ page }) => {
     await page.goto(`${process.env.BASE_URL}/User/new`);
     const nameRequired = page.locator('input[id="name"][required]');
-    await page.fill('input[id="email"]', dataTest.User.email);
     const validationMessage = await nameRequired.evaluate(
       (element) => (element as HTMLInputElement).validationMessage
     );

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -96,6 +96,7 @@ export const options: NextAdminOptions = {
           },
           avatar: {
             format: "file",
+            required: true,
             handler: {
               /*
                * Include your own upload handler here,
@@ -109,6 +110,7 @@ export const options: NextAdminOptions = {
           },
           metadata: {
             format: "json",
+            required: true,
             validate: (value) => {
               try {
                 if (!value) {
@@ -161,6 +163,7 @@ export const options: NextAdminOptions = {
         fields: {
           content: {
             format: "richtext-html",
+            required: true,
           },
           categories: {
             optionFormatter: (category) =>
@@ -189,6 +192,11 @@ export const options: NextAdminOptions = {
       },
       edit: {
         display: ["name", "posts"],
+        fields: {
+          posts: {
+            required: true,
+          },
+        },
       },
     },
   },

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -86,6 +86,9 @@ export const options: NextAdminOptions = {
           metadata: "col-span-4 row-start-9",
         },
         fields: {
+          name: {
+            required: true,
+          },
           email: {
             validate: (email) => email.includes("@") || "form.user.email.error",
             helperText: "Must be a valid email address",
@@ -110,7 +113,6 @@ export const options: NextAdminOptions = {
           },
           metadata: {
             format: "json",
-            required: true,
             validate: (value) => {
               try {
                 if (!value) {
@@ -163,7 +165,6 @@ export const options: NextAdminOptions = {
         fields: {
           content: {
             format: "richtext-html",
-            required: true,
           },
           categories: {
             optionFormatter: (category) =>
@@ -192,11 +193,6 @@ export const options: NextAdminOptions = {
       },
       edit: {
         display: ["name", "posts"],
-        fields: {
-          posts: {
-            required: true,
-          },
-        },
       },
     },
   },

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -99,7 +99,6 @@ export const options: NextAdminOptions = {
           },
           avatar: {
             format: "file",
-            required: true,
             handler: {
               /*
                * Include your own upload handler here,

--- a/apps/example/pageRouterOptions.tsx
+++ b/apps/example/pageRouterOptions.tsx
@@ -72,6 +72,9 @@ export const options: NextAdminOptions = {
           metadata: "col-span-4 row-start-6",
         },
         fields: {
+          name: {
+            required: true,
+          },
           email: {
             validate: (email) => email.includes("@") || "Invalid email",
           },

--- a/packages/next-admin/src/components/Filters.tsx
+++ b/packages/next-admin/src/components/Filters.tsx
@@ -58,19 +58,16 @@ const Filters = <T extends ModelName>({
 
   return (
     currentFilters && (
-        <div
-          {...props}
-          className={clsx("flex flex-wrap gap-2", props.className)}
-        >
-          {currentFilters.map(({ name, active }) => (
-            <Badge
-              onClick={() => toggleFilter(name)}
-              name={name}
-              key={name}
-              isActive={active}
-            />
-          ))}
-        </div>
+      <div {...props} className={clsx("flex flex-wrap gap-2", props.className)}>
+        {currentFilters.map(({ name, active }) => (
+          <Badge
+            onClick={() => toggleFilter(name)}
+            name={name}
+            key={name}
+            isActive={active}
+          />
+        ))}
+      </div>
     )
   );
 };

--- a/packages/next-admin/src/components/Form.tsx
+++ b/packages/next-admin/src/components/Form.tsx
@@ -38,6 +38,7 @@ import {
   ModelAction,
   ModelIcon,
   ModelName,
+  ModelOptions,
   Permission,
   SubmitFormResult,
 } from "../types";
@@ -117,7 +118,8 @@ const Form = ({
 }: FormProps) => {
   const [validation, setValidation] = useState(validationProp);
   const { basePath, options } = useConfig();
-  const modelOptions = options?.model?.[resource];
+  const modelOptions: ModelOptions<typeof resource>[typeof resource] =
+    options?.model?.[resource];
   const canDelete =
     !modelOptions?.permissions ||
     modelOptions?.permissions?.includes(Permission.DELETE);
@@ -127,27 +129,11 @@ const Form = ({
   const canCreate =
     !modelOptions?.permissions ||
     modelOptions?.permissions?.includes(Permission.CREATE);
-  const disabledFields = modelOptions?.edit?.fields
-    ? (Object.entries(modelOptions?.edit?.fields)
-        .map(
-          ([name, opts]: [
-            string,
-            EditFieldsOptions<ModelName>[Field<ModelName>],
-          ]) => {
-            if (opts?.disabled) {
-              return name;
-            }
-
-            return undefined;
-          }
-        )
-        .filter(Boolean) as string[])
-    : [];
   const { edit, id, ...schemas } = getSchemas(
     data,
     schema,
     dmmfSchema,
-    disabledFields
+    modelOptions?.edit?.fields as EditFieldsOptions<typeof resource>
   );
   const { router } = useRouterInternal();
   const { t } = useI18n();
@@ -396,6 +382,7 @@ const Form = ({
         rawErrors,
         schema,
         registry,
+        required,
         ...props
       }: BaseInputTemplateProps) => {
         const onTextChange = ({
@@ -436,6 +423,7 @@ const Form = ({
               value={props.value}
               schema={schema}
               disabled={props.disabled}
+              required={required}
             />
           );
         }

--- a/packages/next-admin/src/components/Form.tsx
+++ b/packages/next-admin/src/components/Form.tsx
@@ -193,6 +193,7 @@ const Form = ({
               className="flex gap-2"
               name="__admin_action"
               value="delete"
+              formNoValidate
               tabIndex={-1}
               onClick={(e) => {
                 if (!confirm(t("form.delete.alert"))) {
@@ -382,7 +383,6 @@ const Form = ({
         rawErrors,
         schema,
         registry,
-        required,
         ...props
       }: BaseInputTemplateProps) => {
         const onTextChange = ({
@@ -423,7 +423,7 @@ const Form = ({
               value={props.value}
               schema={schema}
               disabled={props.disabled}
-              required={required}
+              required={props.required}
             />
           );
         }

--- a/packages/next-admin/src/components/List.tsx
+++ b/packages/next-admin/src/components/List.tsx
@@ -207,7 +207,7 @@ function List({
         />
 
         <div className="bg-nextadmin-background-default dark:bg-dark-nextadmin-background-default max-w-full p-4 align-middle sm:p-8">
-          <div className="sm:-mt-4 sm:mb-4 -mt-2 mb-2 space-y-4">
+          <div className="-mt-2 mb-2 space-y-4 sm:-mt-4 sm:mb-4">
             <Message />
             <Filters filters={filterOptions!} />
           </div>

--- a/packages/next-admin/src/components/inputs/ArrayField.tsx
+++ b/packages/next-admin/src/components/inputs/ArrayField.tsx
@@ -2,13 +2,14 @@ import { FieldProps } from "@rjsf/utils";
 import MultiSelectWidget from "./MultiSelect/MultiSelectWidget";
 
 const ArrayField = (props: FieldProps) => {
-  const { formData, onChange, name, disabled, schema } = props;
+  const { formData, onChange, name, disabled, schema, required } = props;
   return (
     <MultiSelectWidget
       onChange={onChange}
       formData={formData}
       name={name}
       disabled={disabled}
+      required={required}
       schema={schema}
     />
   );

--- a/packages/next-admin/src/components/inputs/CheckboxWidget.tsx
+++ b/packages/next-admin/src/components/inputs/CheckboxWidget.tsx
@@ -12,10 +12,10 @@ const CheckboxWidget = ({
     <div className="relative flex items-start py-1">
       <div className="flex h-5 items-center">
         <input
-          type="hidden"
-          value={value ? "on" : "off"}
+          defaultValue={value ? "on" : "off"}
           name={props.name}
           className="absolute inset-0 -z-10 h-full w-full opacity-0"
+          required={props.required}
         />
         <SwitchRoot
           checked={value}

--- a/packages/next-admin/src/components/inputs/DateTimeWidget.tsx
+++ b/packages/next-admin/src/components/inputs/DateTimeWidget.tsx
@@ -1,11 +1,11 @@
 import {
-  getTemplate,
-  localToUTC,
-  utcToLocal,
   FormContextType,
   RJSFSchema,
   StrictRJSFSchema,
   WidgetProps,
+  getTemplate,
+  localToUTC,
+  utcToLocal,
 } from "@rjsf/utils";
 import { useMemo } from "react";
 
@@ -32,7 +32,12 @@ export default function DateTimeWidget<
 
   return (
     <>
-      <input type="hidden" name={name} value={hiddenValue} />
+      <input
+        name={name}
+        defaultValue={hiddenValue}
+        className="absolute inset-0 -z-10 h-full w-full opacity-0"
+        required={props.required}
+      />
       <BaseInputTemplate
         type="datetime-local"
         {...props}

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -178,7 +178,7 @@ const FileWidget = (props: WidgetProps) => {
           >
             <div className="text-nextadmin-content-inverted/50 dark:text-dark-nextadmin-content-inverted/50 text-center">
               <CloudArrowUpIcon className="mx-auto h-8 w-8" />
-              <div className=" mt-4 flex text-sm leading-6">
+              <div className="mt-4 flex text-sm leading-6">
                 <label
                   htmlFor={props.id}
                   className={clsx(

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -90,7 +90,7 @@ const FileWidget = (props: WidgetProps) => {
 
   return (
     <div className="relative">
-      <div className="relative hover: flex flex-col items-start gap-3 py-1">
+      <div className="hover: relative flex flex-col items-start gap-3 py-1">
         {fileInfo && (
           <div className="flex items-end gap-4">
             <div className="relative flex flex-col items-center gap-1 space-x-2">
@@ -191,7 +191,7 @@ const FileWidget = (props: WidgetProps) => {
                   <span>{t("form.widgets.file_upload.label")}</span>
                   <input
                     type="file"
-                    className="absolute inset-0 cursor-pointer h-full w-full opacity-0"
+                    className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
                     ref={inputRef}
                     id={props.id}
                     disabled={props.disabled}

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -90,7 +90,7 @@ const FileWidget = (props: WidgetProps) => {
 
   return (
     <div className="relative">
-      <div className="relative flex flex-col items-start gap-3 py-1">
+      <div className="relative hover: flex flex-col items-start gap-3 py-1">
         {fileInfo && (
           <div className="flex items-end gap-4">
             <div className="relative flex flex-col items-center gap-1 space-x-2">
@@ -178,11 +178,11 @@ const FileWidget = (props: WidgetProps) => {
           >
             <div className="text-nextadmin-content-inverted/50 dark:text-dark-nextadmin-content-inverted/50 text-center">
               <CloudArrowUpIcon className="mx-auto h-8 w-8" />
-              <div className="mt-4 flex text-sm leading-6">
+              <div className=" mt-4 flex text-sm leading-6">
                 <label
                   htmlFor={props.id}
                   className={clsx(
-                    "text-nextadmin-primary-600 hover:text-nextadmin-primary-500 relative cursor-pointer rounded-md font-semibold focus-visible:outline-none",
+                    "text-nextadmin-primary-600 hover:text-nextadmin-primary-500 cursor-pointer rounded-md font-semibold focus-visible:outline-none",
                     {
                       "cursor-not-allowed": props.disabled,
                     }
@@ -191,7 +191,7 @@ const FileWidget = (props: WidgetProps) => {
                   <span>{t("form.widgets.file_upload.label")}</span>
                   <input
                     type="file"
-                    className="sr-only"
+                    className="absolute inset-0 cursor-pointer h-full w-full opacity-0"
                     ref={inputRef}
                     id={props.id}
                     disabled={props.disabled}

--- a/packages/next-admin/src/components/inputs/JsonField.tsx
+++ b/packages/next-admin/src/components/inputs/JsonField.tsx
@@ -1,12 +1,12 @@
 "use client";
 import Editor from "@monaco-editor/react";
 import { useMemo } from "react";
-import { CustomInputProps } from "../../types";
 import { useColorScheme } from "../../context/ColorSchemeContext";
+import { CustomInputProps } from "../../types";
 
 type Props = CustomInputProps;
 
-const JsonField = ({ value, onChange, name, disabled }: Props) => {
+const JsonField = ({ value, onChange, name, disabled, required }: Props) => {
   const { colorScheme } = useColorScheme();
 
   const defaultValue = useMemo(() => {
@@ -15,11 +15,16 @@ const JsonField = ({ value, onChange, name, disabled }: Props) => {
     } catch {
       return "";
     }
-  }, []);
+  }, [value]);
 
   return (
-    <>
-      <input type="hidden" name={name} value={value ?? ""} />
+    <div className="relative">
+      <input
+        name={name}
+        defaultValue={value ?? ""}
+        className="absolute inset-0 -z-10 h-full w-full opacity-0"
+        required={required}
+      />
       <Editor
         height="20vh"
         defaultLanguage="json"
@@ -35,7 +40,7 @@ const JsonField = ({ value, onChange, name, disabled }: Props) => {
         theme={colorScheme === "light" ? "light" : "vs-dark"}
         className="dark:bg-dark-nextadmin-background-subtle dark:ring-dark-nextadmin-border-strong text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted ring-nextadmin-border-default focus:ring-nextadmin-brand-default dark:focus:ring-dark-nextadmin-brand-default block w-full rounded-md border-0 px-2 py-1.5 text-sm shadow-sm ring-1 ring-inset transition-all duration-300 placeholder:text-gray-400 focus:ring-1 focus:ring-inset disabled:cursor-not-allowed disabled:opacity-50 sm:leading-6 [&>div]:border-none"
       />
-    </>
+    </div>
   );
 };
 

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectWidget.tsx
@@ -8,8 +8,8 @@ import useCloseOnOutsideClick from "../../../hooks/useCloseOnOutsideClick";
 import { Enumeration, Field, ModelName } from "../../../types";
 import Button from "../../radix/Button";
 import { Selector } from "../Selector";
-import MultiSelectDisplayTable from "./MultiSelectDisplayTable";
 import MultiSelectDisplayList from "./MultiSelectDisplayList";
+import MultiSelectDisplayTable from "./MultiSelectDisplayTable";
 import MultiSelectItem from "./MultiSelectItem";
 
 type Props = {
@@ -18,6 +18,7 @@ type Props = {
   formData: any;
   name: string;
   disabled: boolean;
+  required?: boolean;
   schema: RJSFSchema;
 };
 
@@ -50,7 +51,16 @@ const MultiSelectWidget = (props: Props) => {
 
   return (
     <div className="relative" ref={containerRef}>
-      <input type="hidden" name={name} value={JSON.stringify(selectedValues)} />
+      <select
+        name={name}
+        className="absolute inset-0 -z-10 h-full w-full opacity-0"
+        disabled={props.disabled}
+        required={props.required}
+      >
+        {!(props.required && selectedValues.length === 0) && (
+          <option value={JSON.stringify(selectedValues)} />
+        )}
+      </select>
       {displayMode === "select" && (
         <div className="relative">
           <div

--- a/packages/next-admin/src/components/inputs/RichText/RichTextField.tsx
+++ b/packages/next-admin/src/components/inputs/RichText/RichTextField.tsx
@@ -59,9 +59,10 @@ const RichTextField = ({
       <div className="relative">
         <input
           name={props.name}
-          defaultValue={inputValue}
+          value={inputValue}
           className="absolute inset-0 -z-10 h-full w-full opacity-0"
           required={required}
+          onChange={() => {}}
         />
         <EditorContainer>
           <Toolbar>

--- a/packages/next-admin/src/components/inputs/RichText/RichTextField.tsx
+++ b/packages/next-admin/src/components/inputs/RichText/RichTextField.tsx
@@ -6,7 +6,14 @@ import { Editable, Slate, withReact } from "slate-react";
 import * as Icons from "../../../assets/icons/RichTextActions";
 import { RichTextFormat } from "../../../types";
 import { Button, EditorContainer, Separator, Toolbar } from "./components";
-import { deserialize, renderElement, renderLeaf, serialize } from "./utils";
+import {
+  DEFAULT_HTML_VALUE,
+  DEFAULT_JSON_VALUE,
+  deserialize,
+  renderElement,
+  renderLeaf,
+  serialize,
+} from "./utils";
 
 type RichTextFieldProps = {
   onChange: ChangeEventHandler<HTMLInputElement>;
@@ -47,8 +54,16 @@ const RichTextField = ({
 
   const inputValue = useMemo(() => {
     if (required) {
-      if (format === "html" && value === "<br />") {
+      if (format === "html" && value === DEFAULT_HTML_VALUE) {
         return "";
+      }
+
+      try {
+        if (format === "json" && value === JSON.stringify(DEFAULT_JSON_VALUE)) {
+          return "";
+        }
+      } catch {
+        return value;
       }
     }
     return value ?? "";

--- a/packages/next-admin/src/components/inputs/RichText/RichTextField.tsx
+++ b/packages/next-admin/src/components/inputs/RichText/RichTextField.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import { ChangeEventHandler, useMemo } from "react";
 import { Descendant, createEditor } from "slate";
 import { withHistory } from "slate-history";
@@ -6,7 +7,6 @@ import * as Icons from "../../../assets/icons/RichTextActions";
 import { RichTextFormat } from "../../../types";
 import { Button, EditorContainer, Separator, Toolbar } from "./components";
 import { deserialize, renderElement, renderLeaf, serialize } from "./utils";
-import clsx from "clsx";
 
 type RichTextFieldProps = {
   onChange: ChangeEventHandler<HTMLInputElement>;
@@ -18,12 +18,14 @@ type RichTextFieldProps = {
     format?: string;
   };
   disabled?: boolean;
+  required?: boolean;
 };
 
 const RichTextField = ({
   schema,
   onChange,
   disabled,
+  required,
   ...props
 }: RichTextFieldProps) => {
   const { value } = props;
@@ -43,100 +45,115 @@ const RichTextField = ({
     }
   };
 
+  const inputValue = useMemo(() => {
+    if (required) {
+      if (format === "html" && value === "<br />") {
+        return "";
+      }
+    }
+    return value ?? "";
+  }, [value]);
+
   return (
     <Slate editor={editor} initialValue={initialValue} onChange={handleChange}>
-      <input type="hidden" name={props.name} value={value ?? ""} />
-      <EditorContainer>
-        <Toolbar>
-          <Button
-            format="bold"
-            icon={<Icons.Bold />}
-            title="Bold"
-            disabled={disabled}
-          />
-          <Button
-            format="italic"
-            icon={<Icons.Italic />}
-            title="Italic"
-            disabled={disabled}
-          />
-          <Button
-            format="underline"
-            icon={<Icons.Underline />}
-            title="Underline"
-            disabled={disabled}
-          />
-          <Button
-            format="strikethrough"
-            icon={<Icons.Strikethrough />}
-            title="Strikethrough"
-            disabled={disabled}
-          />
-          <Button
-            format="code"
-            icon={<Icons.Code />}
-            title="Code"
-            disabled={disabled}
-          />
-          <Separator />
-          <Button
-            format="blockquote"
-            icon={<Icons.Quote />}
-            title="Blockquote"
-            disabled={disabled}
-          />
-          <Button
-            format="bulleted-list"
-            icon={<Icons.BullettedList />}
-            title="Bulleted list"
-            disabled={disabled}
-          />
-          <Button
-            format="numbered-list"
-            icon={<Icons.NumberedList />}
-            title="Numbered list"
-            disabled={disabled}
-          />
-          <Separator />
-          <Button
-            format="heading-one"
-            icon={<Icons.Heading level={1} />}
-            title="Heading 1"
-            disabled={disabled}
-          />
-          <Button
-            format="heading-two"
-            icon={<Icons.Heading level={2} />}
-            title="Heading 2"
-            disabled={disabled}
-          />
-          <Button
-            format="heading-three"
-            icon={<Icons.Heading level={3} />}
-            title="Heading 3"
-            disabled={disabled}
-          />
-        </Toolbar>
-        <Editable
-          spellCheck
-          renderElement={renderElement}
-          renderLeaf={renderLeaf}
-          readOnly={disabled}
-          className={clsx(
-            "border-nextadmin-border-default dark:border-dark-nextadmin-border-default bg-nextadmin-background-default text-nextadmin-content-inverted",
-            "ring-nextadmin-border-default",
-            "focus:ring-nextadmin-brand-default",
-            "dark:focus:ring-dark-nextadmin-brand-default",
-            "dark:ring-dark-nextadmin-border-strong",
-            "dark:text-dark-nextadmin-content-inverted",
-            "dark:bg-dark-nextadmin-background-subtle min-h-[200px] rounded-b-md p-3 shadow-sm ring-1 focus:ring-2 focus-visible:outline-none",
-            {
-              "cursor-not-allowed opacity-50": disabled,
-            }
-          )}
-          autoFocus
+      <div className="relative">
+        <input
+          name={props.name}
+          defaultValue={inputValue}
+          className="absolute inset-0 -z-10 h-full w-full opacity-0"
+          required={required}
         />
-      </EditorContainer>
+        <EditorContainer>
+          <Toolbar>
+            <Button
+              format="bold"
+              icon={<Icons.Bold />}
+              title="Bold"
+              disabled={disabled}
+            />
+            <Button
+              format="italic"
+              icon={<Icons.Italic />}
+              title="Italic"
+              disabled={disabled}
+            />
+            <Button
+              format="underline"
+              icon={<Icons.Underline />}
+              title="Underline"
+              disabled={disabled}
+            />
+            <Button
+              format="strikethrough"
+              icon={<Icons.Strikethrough />}
+              title="Strikethrough"
+              disabled={disabled}
+            />
+            <Button
+              format="code"
+              icon={<Icons.Code />}
+              title="Code"
+              disabled={disabled}
+            />
+            <Separator />
+            <Button
+              format="blockquote"
+              icon={<Icons.Quote />}
+              title="Blockquote"
+              disabled={disabled}
+            />
+            <Button
+              format="bulleted-list"
+              icon={<Icons.BullettedList />}
+              title="Bulleted list"
+              disabled={disabled}
+            />
+            <Button
+              format="numbered-list"
+              icon={<Icons.NumberedList />}
+              title="Numbered list"
+              disabled={disabled}
+            />
+            <Separator />
+            <Button
+              format="heading-one"
+              icon={<Icons.Heading level={1} />}
+              title="Heading 1"
+              disabled={disabled}
+            />
+            <Button
+              format="heading-two"
+              icon={<Icons.Heading level={2} />}
+              title="Heading 2"
+              disabled={disabled}
+            />
+            <Button
+              format="heading-three"
+              icon={<Icons.Heading level={3} />}
+              title="Heading 3"
+              disabled={disabled}
+            />
+          </Toolbar>
+          <Editable
+            spellCheck
+            renderElement={renderElement}
+            renderLeaf={renderLeaf}
+            readOnly={disabled}
+            className={clsx(
+              "border-nextadmin-border-default dark:border-dark-nextadmin-border-default bg-nextadmin-background-default text-nextadmin-content-inverted",
+              "ring-nextadmin-border-default",
+              "focus:ring-nextadmin-brand-default",
+              "dark:focus:ring-dark-nextadmin-brand-default",
+              "dark:ring-dark-nextadmin-border-strong",
+              "dark:text-dark-nextadmin-content-inverted",
+              "dark:bg-dark-nextadmin-background-subtle min-h-[200px] rounded-b-md p-3 shadow-sm ring-1 focus:ring-2 focus-visible:outline-none",
+              {
+                "cursor-not-allowed opacity-50": disabled,
+              }
+            )}
+          />
+        </EditorContainer>
+      </div>
     </Slate>
   );
 };

--- a/packages/next-admin/src/components/inputs/RichText/utils.tsx
+++ b/packages/next-admin/src/components/inputs/RichText/utils.tsx
@@ -273,28 +273,35 @@ const ensureRootNodeIsNotTextContent = (el: HTMLElement) => {
   return el;
 };
 
+export const DEFAULT_HTML_VALUE = "<br />";
+
+export const DEFAULT_JSON_VALUE = [
+  { type: "paragraph", children: [{ text: "" }] },
+];
+
+export const setDefaultValue = (s: string) => [
+  { type: "paragraph", children: [{ text: s }] },
+];
+
 export const deserialize = (
   string: string | undefined | null,
   format: RichTextFormat
 ) => {
-  const defaultValue = [{ type: "paragraph", children: [{ text: "" }] }];
-
   if (!string) {
-    return defaultValue;
+    return format === "json" ? DEFAULT_JSON_VALUE : DEFAULT_HTML_VALUE;
   }
 
   if (format === "html") {
     if (typeof window === "undefined") {
-      return defaultValue;
+      return DEFAULT_HTML_VALUE;
     }
-
     const dom = new DOMParser().parseFromString(string, "text/html");
     return deserializeHtml(ensureRootNodeIsNotTextContent(dom.body));
   } else {
     try {
       return JSON.parse(string);
     } catch {
-      return "";
+      return setDefaultValue(string);
     }
   }
 };

--- a/packages/next-admin/src/components/inputs/RichText/utils.tsx
+++ b/packages/next-admin/src/components/inputs/RichText/utils.tsx
@@ -288,7 +288,7 @@ export const deserialize = (
   format: RichTextFormat
 ) => {
   if (!string) {
-    return format === "json" ? DEFAULT_JSON_VALUE : DEFAULT_HTML_VALUE;
+    return DEFAULT_JSON_VALUE;
   }
 
   if (format === "html") {

--- a/packages/next-admin/src/components/inputs/SelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/SelectWidget.tsx
@@ -18,6 +18,7 @@ const SelectWidget = ({
   onChange,
   value,
   disabled,
+  required,
   ...props
 }: WidgetProps) => {
   const formContext = useForm();
@@ -43,17 +44,19 @@ const SelectWidget = ({
   return (
     <div className="relative" ref={containerRef}>
       <div className="ring-nextadmin-border-strong dark:ring-dark-nextadmin-border-strong dark:bg-dark-nextadmin-background-subtle relative flex w-full cursor-default justify-between rounded-md px-3 py-2 text-sm placeholder-gray-500 shadow-sm ring-1">
-        <input
-          type="hidden"
-          value={value?.value || ""}
-          name={props.name}
+        <select
+          name={name}
           className="absolute inset-0 -z-10 h-full w-full opacity-0"
-        />
+          disabled={props.disabled}
+          required={required}
+        >
+          {!(props.required && value?.value) && <option value={value?.value} />}
+        </select>
         <input
           id={props.id}
           readOnly
           className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted h-full w-full flex-1 cursor-default appearance-none bg-transparent focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
-          value={value?.label || ""}
+          value={value?.label ?? ""}
           disabled={disabled}
           onMouseDown={() => {
             if (!disabled) {

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -154,6 +154,10 @@ export type EditFieldsOptions<T extends ModelName> = {
      * a boolean to indicate that the field is read only.
      */
     disabled?: boolean;
+    /**
+     * a boolean to indicate that the field is required
+     */
+    required?: true;
   } & (P extends keyof ObjectField<T>
     ? {
         /**
@@ -633,6 +637,7 @@ export type CustomInputProps = Partial<{
   readonly: boolean;
   rawErrors: string[];
   disabled: boolean;
+  required?: boolean;
 }>;
 
 export type TranslationKeys =

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -155,7 +155,7 @@ export type EditFieldsOptions<T extends ModelName> = {
      */
     disabled?: boolean;
     /**
-     * a boolean to indicate that the field is required
+     * a true value to force a field to be required in the form, note that if the field is required by the Prisma schema, you cannot set `required` to false
      */
     required?: true;
   } & (P extends keyof ObjectField<T>

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -509,7 +509,6 @@ export const formattedFormData = async <M extends ModelName>(
             ) &&
             formData[dmmfPropertyName] instanceof File
           ) {
-            console.log("HERE, i'm call'in handler");
             const uploadHandler =
               editOptions?.[dmmfPropertyName]?.handler?.upload;
             const uploadErrorMessage =
@@ -542,12 +541,6 @@ export const formattedFormData = async <M extends ModelName>(
               }
             }
           } else {
-            console.log(
-              "Forget handler",
-              dmmfPropertyName,
-              dmmfPropertyType,
-              formData[dmmfPropertyName]
-            );
             formattedData[dmmfPropertyName] = formData[dmmfPropertyName];
           }
         }
@@ -766,11 +759,12 @@ export const getFormDataValues = async (req: IncomingMessage) => {
               callback();
             },
             final(callback) {
-              console.log(file)
               if (!file.originalFilename) {
                 files[name] = [null];
               } else {
-                files[name] = [new File([Buffer.concat(chunks)], file.originalFilename)];
+                files[name] = [
+                  new File([Buffer.concat(chunks)], file.originalFilename),
+                ];
               }
               callback();
             },


### PR DESCRIPTION
## Title

Add `required` on form fields option to apply HTML validation on these fields

## Type of Change

- [x] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#257 

## Description

Add `required` to true on field options, note that if this fields is already required according to the Prisma schema you cannot remove the `required`

## Screenshots

![image](https://github.com/premieroctet/next-admin/assets/7901622/27ce4124-7763-4ecf-9898-4d8c66f302e2)

## Testing

New test end2end as `user create client error`

## Impact

No impact 
