### PR TITLE
Enhance FileWidget in form

### DIFF
--- a/.changeset/itchy-lions-relate.md
+++ b/.changeset/itchy-lions-relate.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+Change file handler function parameter type to File (more informations)

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -102,7 +102,7 @@ export const options: NextAdminOptions = {
                * for example you can upload the file to an S3 bucket.
                * Make sure to return a string.
                */
-              upload: async (file: Buffer) => {
+              upload: async (file: File) => {
                 return "https://www.gravatar.com/avatar/00000000000000000000000000000000";
               },
             },

--- a/apps/example/pageRouterOptions.tsx
+++ b/apps/example/pageRouterOptions.tsx
@@ -86,7 +86,7 @@ export const options: NextAdminOptions = {
                * for example you can upload the file to an S3 bucket.
                * Make sure to return a string.
                */
-              upload: async (file: Buffer) => {
+              upload: async (file: File) => {
                 return "https://www.gravatar.com/avatar/00000000000000000000000000000000";
               },
             },

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -1,212 +1,170 @@
-import { CloudArrowUpIcon, DocumentIcon } from "@heroicons/react/24/outline";
+import {
+  CloudArrowUpIcon,
+  DocumentIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
 import { WidgetProps } from "@rjsf/utils";
 import clsx from "clsx";
 import { ChangeEvent, useEffect, useRef, useState } from "react";
 import { useI18n } from "../../context/I18nContext";
 
 const FileWidget = (props: WidgetProps) => {
-  const [fileInfo, setFileInfo] = useState<number | null>(
-    props.value ? props.value : null
-  );
-  const [hasChanged, setHasChanged] = useState(false);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File>();
   const [fileIsImage, setFileIsImage] = useState(false);
-  const [fileImage, setFileImage] = useState<string | null>(props.value);
-  const [fileName, setFileName] = useState<string | null>(null);
-  const [isDeleting, setIsDeleting] = useState(false);
+  const [fileData, setFileData] = useState<string | null>(props.value);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [hasChanged, setHasChanged] = useState(false);
   const { t } = useI18n();
   const [isDragging, setIsDragging] = useState(false);
 
-  const handleFileSelect = (file: File) => {
-    const { size } = file;
-    setFileInfo(size);
-    setFileName(file.name);
-
-    if (file.type.includes("image")) {
-      const reader = new FileReader();
-
-      reader.onload = () => {
-        setFileIsImage(true);
-        setFileImage(reader.result as string);
-      };
-
-      reader.readAsDataURL(file);
-    } else {
-      setFileImage(null);
-      setFileIsImage(false);
-    }
-  };
-
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setHasChanged(true);
-    const selectedFile = event.target.files?.[0];
+    const selectedFile = event.target.files;
     if (selectedFile) {
-      handleFileSelect(selectedFile);
-    }
-  };
-
-  const getFileType = () => {
-    if (!props.value) {
-      return;
-    }
-
-    try {
-      const img = new Image();
-
-      img.onload = () => {
-        setFileIsImage(true);
-        setFileImage(props.value);
-      };
-
-      img.onerror = () => {
-        setFileIsImage(false);
-        setFileImage(props.value);
-      };
-
-      img.src = props.value as string;
-    } catch (error) {
-      setFileIsImage(false);
-    }
-  };
-
-  const onCheckDelete = (evt: ChangeEvent<HTMLInputElement>) => {
-    setIsDeleting(evt.target.checked);
-    if (inputRef.current) {
-      inputRef.current.value = "";
+      setHasChanged(true);
+      setFile(selectedFile[0]);
     }
   };
 
   useEffect(() => {
-    getFileType();
+    if (props.value) {
+      fetch(props.value)
+        .then((res) => {
+          return res.blob();
+        })
+        .then((blob) => {
+          setFile(new File([blob], blob.name, { type: blob.type }));
+        });
+    }
   }, []);
 
-  let isLink = false;
+  const handleDelete = () => {
+    setFile(undefined);
+  };
 
-  try {
-    isLink = Boolean(new URL(props.value as string));
-  } catch (error) {
-    isLink = false;
-  }
+  const handleDrop = (event: React.DragEvent) => {
+    if (!props.disabled) {
+      event.preventDefault();
+      setFile(event.dataTransfer?.files[0]);
+      setIsDragging(false);
+    }
+  };
+
+  useEffect(() => {
+    if (inputRef?.current) {
+      const dataTransfer = new DataTransfer();
+      if (file) {
+        dataTransfer.items.add(file);
+        const reader = new FileReader();
+        reader.onload = () => {
+          setFileIsImage(file.type.includes("image"));
+          if (hasChanged) {
+            setFileData(reader.result as string);
+          }
+        };
+
+        reader.readAsDataURL(file);
+      }
+      inputRef.current.files = dataTransfer.files;
+    }
+  }, [file]);
 
   return (
-    <div className="relative">
-      <div className="relative flex flex-col items-start gap-3 py-1">
-        {fileInfo && (
-          <div className="flex items-end gap-4">
-            <div className="relative flex flex-col items-center gap-1 space-x-2">
-              <a
-                href={isLink ? props.value : undefined}
-                className="relative"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                {fileIsImage ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={fileImage!} alt="file" className="h-32" />
-                ) : (
-                  <DocumentIcon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-12 w-12" />
+    <div className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted relative flex flex-col items-start space-y-2">
+      {!props.disabled && (
+        <div
+          className={clsx(
+            "border-nextadmin-border-default dark:border-dark-nextadmin-border-default hover:bg-dark-nextadmin-background-subtle relative flex w-full justify-center rounded-lg border-2 border-dashed px-6 py-10",
+            {
+              "bg-dark-nextadmin-background-subtle": isDragging,
+              "opacity-50": props.disabled,
+            }
+          )}
+          onDrop={handleDrop}
+          onDragOver={(evt) => {
+            if (!props.disabled) {
+              evt.preventDefault();
+            }
+          }}
+          onDragEnter={(evt) => {
+            if (!props.disabled) {
+              evt.preventDefault();
+              setIsDragging(true);
+            }
+          }}
+          onDragLeave={(evt) => {
+            if (!props.disabled) {
+              evt.preventDefault();
+              setIsDragging(false);
+            }
+          }}
+        >
+          <div className="text-nextadmin-content-inverted/50 dark:text-dark-nextadmin-content-inverted/50 text-center">
+            <CloudArrowUpIcon className="mx-auto h-8 w-8" />
+            <div className="mt-4 flex text-sm leading-6">
+              <label
+                htmlFor={props.id}
+                className={clsx(
+                  "text-nextadmin-primary-600 hover:text-nextadmin-primary-500 rounded-md font-semibold focus-visible:outline-none"
                 )}
-              </a>
-              {!!fileName && (
-                <span className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted ml-2 text-sm font-medium">
-                  {fileName}
-                </span>
-              )}
-            </div>
-            {!props.disabled && (
-              <div
-                className={clsx("relative flex items-start", {
-                  "mb-5": !!fileName,
-                })}
               >
-                <div className="flex h-6 items-center">
-                  <input
-                    id="delete_file"
-                    type="checkbox"
-                    className="h-4 w-4 rounded"
-                    onChange={onCheckDelete}
-                  />
-                </div>
-                <div className="ml-2 text-sm leading-6">
-                  <label
-                    htmlFor="delete_file"
-                    className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted font-medium"
-                  >
-                    {t("form.widgets.file_upload.delete")}
-                  </label>
-                </div>
-              </div>
-            )}
-          </div>
-        )}
-        {((props.disabled && !fileInfo) || !props.disabled) && (
-          <div
-            className={clsx(
-              "border-nextadmin-border-default dark:border-dark-nextadmin-border-strong flex w-full justify-center rounded-lg border border-dashed px-6 py-10",
-              {
-                "bg-dark-nextadmin-background-subtle": isDragging,
-                "opacity-50": props.disabled,
-              }
-            )}
-            onDrop={(evt) => {
-              if (!props.disabled) {
-                evt.preventDefault();
-                const files = evt.dataTransfer.files;
-
-                setHasChanged(true);
-                handleFileSelect(files[0]);
-                setIsDragging(false);
-              }
-            }}
-            onDragOver={(evt) => {
-              if (!props.disabled) {
-                evt.preventDefault();
-              }
-            }}
-            onDragEnter={(evt) => {
-              if (!props.disabled) {
-                evt.preventDefault();
-                setIsDragging(true);
-              }
-            }}
-            onDragLeave={(evt) => {
-              if (!props.disabled) {
-                evt.preventDefault();
-                setIsDragging(false);
-              }
-            }}
-          >
-            <div className="text-nextadmin-content-inverted/50 dark:text-dark-nextadmin-content-inverted/50 text-center">
-              <CloudArrowUpIcon className="mx-auto h-8 w-8" />
-              <div className="mt-4 flex text-sm leading-6">
-                <label
-                  htmlFor={props.id}
+                <span>{t("form.widgets.file_upload.label")}</span>
+                <input
+                  type="file"
                   className={clsx(
-                    "text-nextadmin-primary-600 hover:text-nextadmin-primary-500 relative cursor-pointer rounded-md font-semibold focus-visible:outline-none",
+                    "absolute inset-0 h-full w-full cursor-pointer opacity-0",
                     {
                       "cursor-not-allowed": props.disabled,
                     }
                   )}
-                >
-                  <span>{t("form.widgets.file_upload.label")}</span>
-                  <input
-                    type="file"
-                    className="sr-only"
-                    ref={inputRef}
-                    id={props.id}
-                    disabled={props.disabled}
-                    name={isDeleting || hasChanged ? props.name : ""}
-                    onChange={handleFileChange}
-                  />
-                </label>
-                <p className="pl-1">
-                  {t("form.widgets.file_upload.drag_and_drop")}
-                </p>
-              </div>
+                  ref={inputRef}
+                  id={props.id}
+                  disabled={props.disabled}
+                  name={props.name}
+                  onChange={handleFileChange}
+                />
+              </label>
+              <p className="pl-1">
+                {t("form.widgets.file_upload.drag_and_drop")}
+              </p>
             </div>
           </div>
-        )}
-      </div>
+        </div>
+      )}
+      {file && (
+        <div
+          className={clsx(
+            "ring-nextadmin-border-default dark:ring-dark-nextadmin-border-default relative flex cursor-default items-center justify-between rounded-md px-3 px-8 py-2 text-sm placeholder-gray-500 shadow-sm ring-1"
+          )}
+        >
+          <a
+            href={fileData ?? undefined}
+            className="relative flex flex-1 cursor-pointer flex-col items-center gap-2"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {fileIsImage ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={fileData!} alt="file" className="h-32" />
+            ) : (
+              <DocumentIcon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-10 w-10" />
+            )}
+            {file.name && file.name !== "undefined" && (
+              <span className="text-nextadmin-content-inverted/50 dark:text-dark-nextadmin-content-inverted/50 text-sm">
+                {file.name}
+              </span>
+            )}
+          </a>
+          {
+            <div
+              onClick={handleDelete}
+              className={clsx(props.disabled && "hidden")}
+            >
+              <XMarkIcon className="absolute right-2 top-2 h-5 w-5 cursor-pointer text-gray-400" />
+            </div>
+          }
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -71,14 +71,15 @@ const FileWidget = (props: WidgetProps) => {
 
   return (
     <div className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted relative flex flex-col items-start space-y-2">
-      {!props.disabled && (
+      {
         <div
           className={clsx(
             "border-nextadmin-border-default dark:border-dark-nextadmin-border-default hover:bg-dark-nextadmin-background-subtle relative flex w-full justify-center rounded-lg border-2 border-dashed px-6 py-10",
             {
               "bg-dark-nextadmin-background-subtle": isDragging,
               "opacity-50": props.disabled,
-            }
+            },
+            file && "hidden"
           )}
           onDrop={handleDrop}
           onDragOver={(evt) => {
@@ -112,10 +113,10 @@ const FileWidget = (props: WidgetProps) => {
                 <input
                   type="file"
                   className={clsx(
-                    "absolute inset-0 h-full w-full cursor-pointer opacity-0",
-                    {
-                      "cursor-not-allowed": props.disabled,
-                    }
+                    "absolute inset-0 h-full w-full opacity-0",
+                    props.disabled
+                      ? "point-event-none cursor-not-allowed"
+                      : "cursor-pointer"
                   )}
                   ref={inputRef}
                   id={props.id}
@@ -130,7 +131,7 @@ const FileWidget = (props: WidgetProps) => {
             </div>
           </div>
         </div>
-      )}
+      }
       {file && (
         <div
           className={clsx(

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -204,7 +204,7 @@ export type Handler<
    * @param file
    * @returns
    */
-  upload?: (file: Buffer) => Promise<string>;
+  upload?: (file: File) => Promise<string>;
   /**
    * an optional string displayed in the input field as an error message in case of a failure during the upload handler.
    */

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -507,7 +507,7 @@ export const formattedFormData = async <M extends ModelName>(
             ["data-url", "file"].includes(
               editOptions?.[dmmfPropertyName]?.format ?? ""
             ) &&
-            formData[dmmfPropertyName] instanceof Buffer
+            formData[dmmfPropertyName] instanceof File
           ) {
             const uploadHandler =
               editOptions?.[dmmfPropertyName]?.handler?.upload;
@@ -521,7 +521,7 @@ export const formattedFormData = async <M extends ModelName>(
             } else {
               try {
                 const uploadResult = await uploadHandler(
-                  formData[dmmfPropertyName] as unknown as Buffer
+                  formData[dmmfPropertyName] as unknown as File
                 );
                 if (typeof uploadResult !== "string") {
                   console.warn(
@@ -798,7 +798,7 @@ export const getFormValuesFromFormData = async (formData: FormData) => {
     tmpFormValues[key] = val;
   });
 
-  const formValues = {} as Record<string, string | Buffer | null>;
+  const formValues = {} as Record<string, string | File | null>;
 
   await Promise.allSettled(
     Object.entries(tmpFormValues).map(async ([key, value]) => {
@@ -808,8 +808,7 @@ export const getFormValuesFromFormData = async (formData: FormData) => {
           formValues[key] = null;
           return;
         }
-        const buffer = await file.arrayBuffer();
-        formValues[key] = Buffer.from(buffer);
+        formValues[key] = file;
       } else {
         formValues[key] = value as string;
       }


### PR DESCRIPTION
## Title

Enhance FileWidget in form

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [x] UI/UX improvement

## Description

Enhance FileWidget
Change the `upload` function to take a File object (more file information) instead of a Buffer object.
Preview on file change with `readAsDataURL` 

## Screenshots

<img width="758" alt="image" src="https://github.com/premieroctet/next-admin/assets/7901622/e6d0ac5f-d9e2-4e00-b1ca-d99ef94feadd">

## Impact

Type of `upload` function changes to take a File object.
