### PR TITLE
Add row context

### DIFF
--- a/.changeset/curvy-lobsters-eat.md
+++ b/.changeset/curvy-lobsters-eat.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Add row context to formatter function

--- a/apps/docs/pages/docs/api-docs.mdx
+++ b/apps/docs/pages/docs/api-docs.mdx
@@ -461,6 +461,7 @@ This is the type of the props that are passed to the custom input component:
 The `NextAdmin` context is an object containing the following properties:
 
 - `locale`: the locale used by the calling page. (refers to the `accept-language` header).
+- `row`: the current row of the list view. Represents non-formatted data of the current row.
 
 ## Notice
 

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -274,13 +274,12 @@ export type ListExport = {
   /**
    * a string defining the format of the export. It is mandatory.
    */
-  format: string
+  format: string;
   /**
    * a string defining the URL of the export. It is mandatory.
    */
   url: string;
 };
-
 
 export type ListOptions<T extends ModelName> = {
   /**
@@ -689,6 +688,7 @@ export type SubmitFormResult = {
 
 export type NextAdminContext = {
   locale?: string;
+  row?: any;
 };
 
 export type CustomInputProps = Partial<{

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -318,8 +318,9 @@ export const mapDataList = ({
   const dmmfSchema = getPrismaModelForResource(resource);
   const data = findRelationInData(fetchData, dmmfSchema?.fields);
   const listFields = options.model?.[resource]?.list?.fields ?? {};
-
+  const originalData = cloneDeep(data);
   data.forEach((item, index) => {
+    context.row = originalData[index];
     Object.keys(item).forEach((key) => {
       let itemValue = null;
       const model = capitalize(key) as ModelName;
@@ -357,7 +358,7 @@ export const mapDataList = ({
         itemValue !== null
       ) {
         item[key].__nextadmin_formatted = listFields[
-          key as keyof typeof listFields
+          key as Field<ModelName>
         ]?.formatter?.(itemValue ?? item[key], context);
       } else {
         if (typeof item[key]?.__nextadmin_formatted === "object") {


### PR DESCRIPTION
## Title

Add row context to formatter function param `context`

## Type of Change

- [x] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#334 

## Description

Allow access to current row on context param of formatter field function. This row represents a non-formatter data for current row

## Impact

No Impact
