### PR TITLE
Disable creation button on list based on permission

### DIFF
--- a/.changeset/neat-doors-drive.md
+++ b/.changeset/neat-doors-drive.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Disable creation button on list based on permission

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -93,7 +93,6 @@ export const options: NextAdminOptions = {
         },
         fields: {
           name: {
-
             required: true,
           },
           email: {

--- a/packages/next-admin/src/components/EmptyState.tsx
+++ b/packages/next-admin/src/components/EmptyState.tsx
@@ -2,7 +2,7 @@ import { PlusSmallIcon } from "@heroicons/react/24/outline";
 import Link from "next/link";
 import { useConfig } from "../context/ConfigContext";
 import { useI18n } from "../context/I18nContext";
-import { ModelIcon } from "../types";
+import { ModelIcon, ModelName } from "../types";
 import { slugify } from "../utils/tools";
 import ResourceIcon from "./common/ResourceIcon";
 import { buttonVariants } from "./radix/Button";
@@ -11,11 +11,15 @@ const EmptyState = ({
   resource,
   icon,
 }: {
-  resource: string;
+  resource: ModelName;
   icon?: ModelIcon;
 }) => {
   const { t } = useI18n();
-  const { basePath } = useConfig();
+  const { basePath, options } = useConfig();
+
+  const modelOptions = options?.model?.[resource];
+  const hasCreatePermission =
+    !modelOptions?.permissions || modelOptions?.permissions?.includes("create");
 
   const resourceName = t(`model.${resource}.name`, {}, resource.toLowerCase());
 
@@ -28,25 +32,29 @@ const EmptyState = ({
       <h3 className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-default mt-2 text-lg  font-semibold">
         {t("list.empty.label", { resource: resourceName })}
       </h3>
-      <p className="text-nextadmin-content-emphasis dark:text-dark-nextadmin-content-emphasis mt-1 text-sm ">
-        {t("list.empty.caption", { resource: resourceName })}
-      </p>
-      <div className="mt-6">
-        <Link
-          href={`${basePath}/${slugify(resource)}/new`}
-          role="button"
-          className={buttonVariants({
-            variant: "default",
-            size: "sm",
-          })}
-        >
-          <span>
-            {t("list.header.add.label")} {resourceName}
-          </span>
+      {hasCreatePermission && (
+        <>
+          <p className="text-nextadmin-content-emphasis dark:text-dark-nextadmin-content-emphasis mt-1 text-sm ">
+            {t("list.empty.caption", { resource: resourceName })}
+          </p>
+          <div className="mt-6">
+            <Link
+              href={`${basePath}/${slugify(resource)}/new`}
+              role="button"
+              className={buttonVariants({
+                variant: "default",
+                size: "sm",
+              })}
+            >
+              <span>
+                {t("list.header.add.label")} {resourceName}
+              </span>
 
-          <PlusSmallIcon className="ml-2 h-5 w-5" aria-hidden="true" />
-        </Link>
-      </div>
+              <PlusSmallIcon className="ml-2 h-5 w-5" aria-hidden="true" />
+            </Link>
+          </div>
+        </>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Title

Disable creation button on list based on permission

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement


## Description

On list page, disable creation button if user don't have permissions to create entity

## Screenshots

<img width="1176" alt="image" src="https://github.com/premieroctet/next-admin/assets/7901622/36d19dba-96c0-42f3-a893-fa8d2630e5d3">


## Impact

No impact
