### PR TITLE
Set null value instead of empty string

### DIFF
--- a/.changeset/khaki-frogs-carry.md
+++ b/.changeset/khaki-frogs-carry.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Set null value instead of empty string (#345)

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -722,7 +722,9 @@ export const formattedFormData = async <M extends ModelName>(
           }
         } else {
           const dmmfPropertyName = dmmfProperty.name as keyof ScalarField<M>;
-          if (
+          if (formData[dmmfPropertyName] === "") {
+            formattedData[dmmfPropertyName] = null;
+          } else if (
             dmmfPropertyType === "Int" ||
             dmmfPropertyType === "Float" ||
             dmmfPropertyType === "Decimal"


### PR DESCRIPTION
## Title

Set null value instead of empty string

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#345 

## Description

When field is empty, formData will send `""` (empty string) value, but this value will turn into `null` before submit formData with Prisma

## Impact

No Impact