### PR TITLE
Minify html for richtext and support div

### DIFF
--- a/.changeset/plenty-cooks-smile.md
+++ b/.changeset/plenty-cooks-smile.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Minify html for richtext and support div (#347)

--- a/packages/next-admin/src/components/inputs/RichText/RichTextField.tsx
+++ b/packages/next-admin/src/components/inputs/RichText/RichTextField.tsx
@@ -77,7 +77,7 @@ const RichTextField = ({
           value={inputValue}
           className="absolute inset-0 -z-10 h-full w-full opacity-0"
           required={required}
-          onChange={() => {}}
+          readOnly
         />
         <EditorContainer>
           <Toolbar>
@@ -166,7 +166,7 @@ const RichTextField = ({
               {
                 "cursor-not-allowed opacity-50": disabled,
               },
-              "overflow-y-auto",
+              "h-[150px] overflow-y-auto",
               "resize-y"
             )}
           />

--- a/packages/next-admin/src/components/inputs/RichText/utils.tsx
+++ b/packages/next-admin/src/components/inputs/RichText/utils.tsx
@@ -184,8 +184,12 @@ export const renderElement = (props: RenderElementProps) => {
       );
     case "br":
       return <>{children}</>;
-    default:
+    case "pargraph":
       return <p {...attributes}>{children}</p>;
+    case "div":
+      return <div {...attributes}>{children}</div>;
+    default:
+      return <>{children}</>;
   }
 };
 
@@ -245,8 +249,10 @@ export const serializeHtml = (node: Node) => {
       return `<h3>${children}</h3>`;
     case "blockquote":
       return `<blockquote>${children}</blockquote>`;
-    default:
+    case "paragraph":
       return `<p>${children}</p>`;
+    default:
+      return `<div>${children}</div>`;
   }
 };
 
@@ -295,7 +301,8 @@ export const deserialize = (
     if (typeof window === "undefined") {
       return DEFAULT_HTML_VALUE;
     }
-    const dom = new DOMParser().parseFromString(string, "text/html");
+    const html = string.replace(/>\s+</g, "><");
+    const dom = new DOMParser().parseFromString(html, "text/html");
     return deserializeHtml(ensureRootNodeIsNotTextContent(dom.body));
   } else {
     try {
@@ -390,6 +397,11 @@ export const deserializeHtml = (
     case "LI":
       return {
         type: "list-item",
+        children,
+      };
+    case "DIV":
+      return {
+        type: "div",
         children,
       };
     default:


### PR DESCRIPTION
## Title

Auto minify all HTML from database when using richtext input, add support of div for external set of this fields

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#347 

## Impact

No Impact

## Additional Information

> Note that if you put html directly into you database and try to see it in nextadmin you need to make sure that this is a valid HTML and that it does not contain unsupported tags
