### PR TITLE
Fix selection in form for Safari browser

### DIFF
--- a/.changeset/six-cherries-explain.md
+++ b/.changeset/six-cherries-explain.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Fix selection in form for Safari browser

--- a/packages/next-admin/src/components/inputs/SelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/SelectWidget.tsx
@@ -57,7 +57,7 @@ const SelectWidget = ({
             disabled ? "cursor-not-allowed" : "cursor-pointer"
           )}
           disabled={disabled}
-          required={required}
+          required={required && !hasValue}
           onMouseDown={(e) => {
             e.preventDefault();
             if (!disabled) {


### PR DESCRIPTION
## Title

Fix selection in form for Safari browser

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#355 

## Description

Fix selection in form for Safari browser. Problem due to required selection on Safari Browser

## Testing

test e2e of CRUD

## Impact

No impact
