### PR TITLE
Don't prefetch export Link

### DIFF
--- a/.changeset/eight-buses-admire.md
+++ b/.changeset/eight-buses-admire.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Don't prefetch export Link in header

--- a/packages/next-admin/src/components/ExportDropdown.tsx
+++ b/packages/next-admin/src/components/ExportDropdown.tsx
@@ -65,7 +65,7 @@ const ExportDropdown = ({ exports }: Props) => {
                   key={format}
                   className={clsx("cursor-pointer rounded-md px-2 py-1")}
                 >
-                  <Link href={url} target="_blank">
+                  <Link prefetch={false} href={url} target="_blank">
                     {t("list.row.actions.export", { format: format })}
                   </Link>
                 </DropdownItem>

--- a/packages/next-admin/src/components/ListHeader.tsx
+++ b/packages/next-admin/src/components/ListHeader.tsx
@@ -10,7 +10,6 @@ import { ChangeEvent, useMemo } from "react";
 import Loader from "../assets/icons/Loader";
 import { useConfig } from "../context/ConfigContext";
 import { useI18n } from "../context/I18nContext";
-import { SPECIFIC_IDS_TO_RUN_ACTION } from "../hooks/useAction";
 import {
   ModelAction,
   ModelIcon,

--- a/packages/next-admin/src/components/ListHeader.tsx
+++ b/packages/next-admin/src/components/ListHeader.tsx
@@ -10,6 +10,7 @@ import { ChangeEvent, useMemo } from "react";
 import Loader from "../assets/icons/Loader";
 import { useConfig } from "../context/ConfigContext";
 import { useI18n } from "../context/I18nContext";
+import { SPECIFIC_IDS_TO_RUN_ACTION } from "../hooks/useAction";
 import {
   ModelAction,
   ModelIcon,
@@ -35,8 +36,6 @@ type Props = {
   title: string;
   icon?: ModelIcon;
   totalCount?: number;
-  canCreate?: boolean;
-  canDelete?: boolean;
 };
 
 export default function ListHeader({
@@ -144,6 +143,7 @@ export default function ListHeader({
               <ExportDropdown exports={modelOptions?.list?.exports} />
             ) : (
               <Link
+                prefetch={false}
                 href={modelOptions?.list?.exports.url}
                 target="_blank"
                 className="text-nextadmin-content-inverted dark:text-dark-nextadmin-brand-inverted border-nextadmin-border-default dark:border-dark-nextadmin-border-default dark:bg-dark-nextadmin-background-subtle flex min-w-fit items-center gap-x-2 rounded-md border bg-transparent px-3 py-2 text-sm"


### PR DESCRIPTION
## Title

NextJS automatically prefetch all `<Link/>` and cause `404` when trying to prefetch Exports link

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

