### PR TITLE
fix: file widget cors error

### DIFF
--- a/.changeset/great-bees-pump.md
+++ b/.changeset/great-bees-pump.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Fix images CORS issues

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -12,6 +12,7 @@
     "big-bobcats-occur",
     "chilled-llamas-grab",
     "gentle-cooks-tickle",
+    "great-bees-pump",
     "quiet-otters-study",
     "spotty-forks-greet",
     "stale-cycles-peel",

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,8 +19,6 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
-      - name: Check docker-compose
-        run: docker-compose --version
       - name: Start docker-compose
         run: docker-compose up -d
       - name: Install dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
+      - name: Check docker-compose
+        run: docker-compose --version
       - name: Start docker-compose
         run: docker-compose up -d
       - name: Install dependencies

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,7 +20,7 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
       - name: Start docker-compose
-        run: docker-compose up -d
+        run: docker compose up -d
       - name: Install dependencies
         run: yarn install
       - name: Run linter

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.1.1",
-    "@premieroctet/next-admin": "5.0.0-rc.11",
+    "@premieroctet/next-admin": "5.0.0-rc.12",
     "clsx": "^2.1.0",
     "framer-motion": "^11.0.8",
     "mini-svg-data-uri": "^1.4.4",

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -104,7 +104,7 @@ export const options: NextAdminOptions = {
                * Make sure to return a string.
                */
               upload: async (buffer, infos) => {
-                return "https://www.gravatar.com/avatar/00000000000000000000000000000000";
+                return "https://raw.githubusercontent.com/premieroctet/next-admin/33fcd755a34f1ec5ad53ca8e293029528af814ca/apps/example/public/assets/logo.svg";
               },
             },
           },

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@heroicons/react": "^2.0.18",
     "@picocss/pico": "^1.5.7",
-    "@premieroctet/next-admin": "5.0.0-rc.11",
+    "@premieroctet/next-admin": "5.0.0-rc.12",
     "@prisma/client": "5.14.0",
     "@tremor/react": "^3.2.2",
     "babel-plugin-superjson-next": "^0.4.5",

--- a/apps/example/pageRouterOptions.tsx
+++ b/apps/example/pageRouterOptions.tsx
@@ -76,8 +76,8 @@ export const options: NextAdminOptions = {
                * for example you can upload the file to an S3 bucket.
                * Make sure to return a string.
                */
-              upload: async (file, infos) => {
-                return "https://www.gravatar.com/avatar/00000000000000000000000000000000";
+              upload: async (buffer, infos) => {
+                return "https://raw.githubusercontent.com/premieroctet/next-admin/33fcd755a34f1ec5ad53ca8e293029528af814ca/apps/example/public/assets/logo.svg";
               },
             },
           },

--- a/packages/next-admin/CHANGELOG.md
+++ b/packages/next-admin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @premieroctet/next-admin
 
+## 5.0.0-rc.12
+
+### Patch Changes
+
+- [170a48b](https://github.com/premieroctet/next-admin/commit/170a48b): Fix images CORS issues
+
 ## 5.0.0-rc.11
 
 ### Patch Changes

--- a/packages/next-admin/package.json
+++ b/packages/next-admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@premieroctet/next-admin",
-  "version": "5.0.0-rc.11",
+  "version": "5.0.0-rc.12",
   "main": "./dist/index.js",
   "description": "Next-Admin provides a customizable and turnkey admin dashboard for applications built with Next.js and powered by the Prisma ORM. It aims to simplify the development process by providing a turnkey admin system that can be easily integrated into your project.",
   "keywords": [

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -9,12 +9,7 @@ import { ChangeEvent, useEffect, useRef, useState } from "react";
 import Loader from "../../assets/icons/Loader";
 import { useFormState } from "../../context/FormStateContext";
 import { useI18n } from "../../context/I18nContext";
-import {
-  getFilenameFromUrl,
-  getMimeTypeFromUrl,
-  isImageMimeType,
-} from "../../utils/file";
-
+import { getFilenameFromUrl, isImageType } from "../../utils/file";
 
 const FileWidget = (props: WidgetProps) => {
   const [file, setFile] = useState<File>();
@@ -38,7 +33,6 @@ const FileWidget = (props: WidgetProps) => {
   };
 
   useEffect(() => {
-    console.log("props.value", props.value);
     if (props.value) {
       setIsPending(true);
       setFileUrl(props.value);
@@ -46,10 +40,7 @@ const FileWidget = (props: WidgetProps) => {
       if (filename) {
         setFilename(filename);
       }
-      const mime = getMimeTypeFromUrl(props.value);
-      if (mime) {
-        setFileIsImage(isImageMimeType(mime));
-      }
+      setFileIsImage(isImageType(props.value));
       setIsPending(false);
     } else {
       setIsPending(false);

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -19,7 +19,7 @@ const FileWidget = (props: WidgetProps) => {
   const [file, setFile] = useState<File>();
   const [errors, setErrors] = useState(props.rawErrors);
   const [fileIsImage, setFileIsImage] = useState(false);
-  const [fileName, setFileName] = useState<string | null>(null);
+  const [filename, setFilename] = useState<string | null>(null);
   const [fileUrl, setFileUrl] = useState<string | null>(props.value);
   const [isPending, setIsPending] = useState(false);
 
@@ -40,7 +40,7 @@ const FileWidget = (props: WidgetProps) => {
     if (props.value) {
       setIsPending(true);
       setFileUrl(props.value);
-      setFileName(getFilenameFromUrl(props.value) ?? null);
+      setFilename(getFilenameFromUrl(props.value) ?? null);
       const mime = getMimeTypeFromUrl(props.value);
       if (mime) {
         setFileIsImage(isImageMimeType(mime));
@@ -54,7 +54,7 @@ const FileWidget = (props: WidgetProps) => {
   const handleDelete = () => {
     setFile(undefined);
     setFileUrl(null);
-    setFileName(null);
+    setFilename(null);
     setErrors(undefined);
     setFieldDirty(props.name);
   };
@@ -76,7 +76,7 @@ const FileWidget = (props: WidgetProps) => {
         reader.onload = () => {
           setFileIsImage(file.type.includes("image"));
           setFileUrl(reader.result as string);
-          setFileName(file.name);
+          setFilename(file.name);
         };
 
         reader.readAsDataURL(file);
@@ -176,9 +176,9 @@ const FileWidget = (props: WidgetProps) => {
                 <DocumentIcon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-10 w-10" />
               ))}
 
-            {!!fileName && (
+            {!!filename && (
               <span className="text-nextadmin-content-inverted/50 dark:text-dark-nextadmin-content-inverted/50 text-sm">
-                {fileName}
+                {filename}
               </span>
             )}
           </a>

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -176,7 +176,7 @@ const FileWidget = (props: WidgetProps) => {
                 <DocumentIcon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-10 w-10" />
               ))}
 
-            {fileName !== undefined && (
+            {!!fileName && (
               <span className="text-nextadmin-content-inverted/50 dark:text-dark-nextadmin-content-inverted/50 text-sm">
                 {fileName}
               </span>

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -5,20 +5,25 @@ import {
 } from "@heroicons/react/24/outline";
 import { WidgetProps } from "@rjsf/utils";
 import clsx from "clsx";
-import { ChangeEvent, memo, useEffect, useRef, useState } from "react";
+import { ChangeEvent, useEffect, useRef, useState } from "react";
 import Loader from "../../assets/icons/Loader";
 import { useFormState } from "../../context/FormStateContext";
 import { useI18n } from "../../context/I18nContext";
+import {
+  getFilenameFromUrl,
+  getMimeTypeFromUrl,
+  isImageMimeType,
+} from "../../utils/file";
 
 const FileWidget = (props: WidgetProps) => {
   const [file, setFile] = useState<File>();
   const [errors, setErrors] = useState(props.rawErrors);
   const [fileIsImage, setFileIsImage] = useState(false);
-  const [fileData, setFileData] = useState<string | null>(props.value);
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [fileUrl, setFileUrl] = useState<string | null>(props.value);
   const [isPending, setIsPending] = useState(false);
 
   const inputRef = useRef<HTMLInputElement>(null);
-  const [hasChanged, setHasChanged] = useState(false);
   const { t } = useI18n();
   const [isDragging, setIsDragging] = useState(false);
   const { setFieldDirty } = useFormState();
@@ -26,7 +31,6 @@ const FileWidget = (props: WidgetProps) => {
   const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
     const selectedFile = event.target.files;
     if (selectedFile) {
-      setHasChanged(true);
       setFieldDirty(props.name);
       setFile(selectedFile[0]);
     }
@@ -35,19 +39,13 @@ const FileWidget = (props: WidgetProps) => {
   useEffect(() => {
     if (props.value) {
       setIsPending(true);
-      fetch(props.value)
-        .then((res) => {
-          return res.blob();
-        })
-        .then((blob) => {
-          setFile(new File([blob], blob.name, { type: blob.type }));
-        })
-        .catch((error) => {
-          setErrors([error.message]);
-        })
-        .finally(() => {
-          setIsPending(false);
-        });
+      setFileUrl(props.value);
+      setFileName(getFilenameFromUrl(props.value) ?? null);
+      const mime = getMimeTypeFromUrl(props.value);
+      if (mime) {
+        setFileIsImage(isImageMimeType(mime));
+      }
+      setIsPending(false);
     } else {
       setIsPending(false);
     }
@@ -55,7 +53,8 @@ const FileWidget = (props: WidgetProps) => {
 
   const handleDelete = () => {
     setFile(undefined);
-    setFileData(null);
+    setFileUrl(null);
+    setFileName(null);
     setErrors(undefined);
     setFieldDirty(props.name);
   };
@@ -76,9 +75,8 @@ const FileWidget = (props: WidgetProps) => {
         const reader = new FileReader();
         reader.onload = () => {
           setFileIsImage(file.type.includes("image"));
-          if (hasChanged) {
-            setFileData(reader.result as string);
-          }
+          setFileUrl(reader.result as string);
+          setFileName(file.name);
         };
 
         reader.readAsDataURL(file);
@@ -97,7 +95,7 @@ const FileWidget = (props: WidgetProps) => {
               "bg-dark-nextadmin-background-subtle": isDragging,
               "opacity-50": props.disabled,
             },
-            (file || isPending || errors) && "hidden"
+            (fileUrl || isPending || errors) && "hidden"
           )}
           onDrop={handleDrop}
           onDragOver={(evt) => {
@@ -151,7 +149,7 @@ const FileWidget = (props: WidgetProps) => {
           </div>
         </div>
       }
-      {(isPending || file || errors) && (
+      {(isPending || errors || fileUrl) && (
         <div
           className={clsx(
             "ring-nextadmin-border-default dark:ring-dark-nextadmin-border-default relative flex cursor-default items-center justify-between rounded-md px-3 px-8 py-2 text-sm placeholder-gray-500 shadow-sm ring-1",
@@ -159,7 +157,7 @@ const FileWidget = (props: WidgetProps) => {
           )}
         >
           <a
-            href={fileData ?? undefined}
+            href={fileUrl ?? undefined}
             className="relative flex flex-1 cursor-pointer flex-col items-center gap-2"
             target="_blank"
             rel="noopener noreferrer"
@@ -173,14 +171,14 @@ const FileWidget = (props: WidgetProps) => {
             {!isPending &&
               (fileIsImage ? (
                 // eslint-disable-next-line @next/next/no-img-element
-                <img src={fileData!} alt="file" className="h-32" />
+                <img src={fileUrl!} alt="file" className="h-32" />
               ) : (
                 <DocumentIcon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-10 w-10" />
               ))}
 
-            {file && file.name && file.name !== "undefined" && (
+            {fileName !== undefined && (
               <span className="text-nextadmin-content-inverted/50 dark:text-dark-nextadmin-content-inverted/50 text-sm">
-                {file.name}
+                {fileName}
               </span>
             )}
           </a>

--- a/packages/next-admin/src/components/inputs/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget.tsx
@@ -15,6 +15,7 @@ import {
   isImageMimeType,
 } from "../../utils/file";
 
+
 const FileWidget = (props: WidgetProps) => {
   const [file, setFile] = useState<File>();
   const [errors, setErrors] = useState(props.rawErrors);
@@ -37,10 +38,14 @@ const FileWidget = (props: WidgetProps) => {
   };
 
   useEffect(() => {
+    console.log("props.value", props.value);
     if (props.value) {
       setIsPending(true);
       setFileUrl(props.value);
-      setFilename(getFilenameFromUrl(props.value) ?? null);
+      const filename = getFilenameFromUrl(props.value);
+      if (filename) {
+        setFilename(filename);
+      }
       const mime = getMimeTypeFromUrl(props.value);
       if (mime) {
         setFileIsImage(isImageMimeType(mime));

--- a/packages/next-admin/src/utils/file.test.ts
+++ b/packages/next-admin/src/utils/file.test.ts
@@ -1,0 +1,136 @@
+import {
+  getFilenameAndExtensionFromUrl,
+  getFilenameFromUrl,
+  isBase64Url,
+  isImageType,
+} from "./file";
+
+describe("File utils", () => {
+  describe("isBase64Url", () => {
+    const base64Data =
+      "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=";
+    it("should return true for full base64 url", () => {
+      expect(isBase64Url(`data:image/png;base64,${base64Data}`)).toBeTruthy();
+    });
+
+    it("should return false for website urls ", () => {
+      expect(isBase64Url("https://example.com/image.png")).toBeFalsy();
+    });
+
+    it("should return false for relative urls", () => {
+      expect(isBase64Url("/image.png")).toBeFalsy();
+    });
+
+    it("should return false for empty strings", () => {
+      expect(isBase64Url("")).toBeFalsy();
+    });
+
+    it("should return false for base64 strings without prefix", () => {
+      expect(isBase64Url(base64Data)).toBeFalsy();
+    });
+  });
+
+  describe("isImageType", () => {
+    it("should return true for image urls", () => {
+      expect(isImageType("https://example.com/image.png")).toBeTruthy();
+    });
+
+    it("should return true for image urls with query parameters", () => {
+      expect(
+        isImageType("https://example.com/image.jpg?width=100&height=100")
+      ).toBeTruthy();
+    });
+
+    it("should return true for base64 image urls", () => {
+      expect(
+        isImageType(
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+        )
+      ).toBeTruthy();
+    });
+
+    it("should return false for non-image urls", () => {
+      expect(isImageType("https://example.com/document.pdf")).toBeFalsy();
+    });
+
+    it("should return false for urls without extensions", () => {
+      expect(isImageType("https://example.com/no-extension")).toBeFalsy();
+    });
+
+    it("should return false for empty strings", () => {
+      expect(isImageType("")).toBeFalsy();
+    });
+
+    it("should return true for image urls with uppercase extensions", () => {
+      expect(isImageType("https://example.com/image.PNG")).toBeTruthy();
+    });
+
+    it("should return true for image urls with anchor tags", () => {
+      expect(isImageType("https://example.com/image.png#anchor")).toBeTruthy();
+    });
+  });
+
+  describe("getFilenameAndExtensionFromUrl", () => {
+    it("should return filename and extension for a simple url", () => {
+      expect(
+        getFilenameAndExtensionFromUrl("https://example.com/image.jpg")
+      ).toEqual({
+        fileName: "image.jpg",
+        extension: "jpg",
+      });
+    });
+
+    it("should handle urls with query parameters", () => {
+      expect(
+        getFilenameAndExtensionFromUrl(
+          "https://example.com/document.pdf?version=1"
+        )
+      ).toEqual({
+        fileName: "document.pdf",
+        extension: "pdf",
+      });
+    });
+
+    it("should handle urls with hash", () => {
+      expect(
+        getFilenameAndExtensionFromUrl("https://example.com/page.html#section1")
+      ).toEqual({
+        fileName: "page.html",
+        extension: "html",
+      });
+    });
+
+    it("should return undefined for urls without filename", () => {
+      expect(getFilenameAndExtensionFromUrl("https://example.com/")).toEqual({
+        fileName: undefined,
+        extension: undefined,
+      });
+    });
+  });
+
+  describe("getFilenameFromUrl", () => {
+    it("should return filename for a simple url", () => {
+      expect(getFilenameFromUrl("https://example.com/image.jpg")).toBe(
+        "image.jpg"
+      );
+    });
+
+    it("should handle urls with query parameters", () => {
+      expect(
+        getFilenameFromUrl("https://example.com/document.pdf?version=1")
+      ).toBe("document.pdf");
+    });
+
+    it("should return undefined for base64 urls", () => {
+      expect(
+        getFilenameFromUrl(
+          "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+        )
+      ).toBeUndefined();
+    });
+
+    it("should return undefined for urls without filename", () => {
+      expect(getFilenameFromUrl("https://example.com/")).toBeUndefined();
+    });
+  });
+});

--- a/packages/next-admin/src/utils/file.ts
+++ b/packages/next-admin/src/utils/file.ts
@@ -1,0 +1,64 @@
+export function isImageMimeType(mimeType: string) {
+  if (mimeType.startsWith("image")) {
+    return true;
+  } else if (
+    [
+      "jpg",
+      "jpeg",
+      "png",
+      "gif",
+      "bmp",
+      "webp",
+      "svg",
+      "ico",
+      "tiff",
+      "tif",
+    ].includes(mimeType)
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+export function isBase64Url(url: string) {
+  return url.startsWith("data:");
+}
+
+export function getFilenameAndExtensionFromUrl(url: string) {
+  const regex = /([\w-]+)(\.[\w-]+)+(?!.*\/)/gm;
+  const match = regex.exec(url);
+  if (match && match.length > 2) {
+    return {
+      fileName: `${match[1]}${match[2]}`,
+      extension: match[2],
+    };
+  } else {
+    return {
+      fileName: "",
+      extension: "",
+    };
+  }
+}
+
+export function getMimeTypeFromUrl(url: string) {
+  if (isBase64Url(url)) {
+    return url.split(":")[1].split(";")[0];
+  } else {
+    const { extension } = getFilenameAndExtensionFromUrl(url);
+    if (!!extension) {
+      return extension.replace(".", "");
+    } else {
+      return undefined;
+    }
+  }
+}
+
+export function getFilenameFromUrl(url: string) {
+  if (isBase64Url(url)) {
+    return undefined;
+  } else {
+    const { fileName } = getFilenameAndExtensionFromUrl(url);
+    return fileName;
+  }
+}

--- a/packages/next-admin/src/utils/file.ts
+++ b/packages/next-admin/src/utils/file.ts
@@ -1,25 +1,22 @@
-export function isImageMimeType(mimeType: string) {
-  if (mimeType.startsWith("image")) {
-    return true;
-  } else if (
-    [
-      "jpg",
-      "jpeg",
-      "png",
-      "gif",
-      "bmp",
-      "webp",
-      "svg",
-      "ico",
-      "tiff",
-      "tif",
-    ].includes(mimeType)
-  ) {
-    return true;
-  } else {
-    return false;
-  }
-}
+const SUPPORTED_IMG_EXTENSIONS = [
+  ".apng",
+  ".avif",
+  ".png",
+  ".gif",
+  ".jpg",
+  ".jpeg",
+  ".jfif",
+  ".pjpeg",
+  ".pjp",
+  ".png",
+  ".svg",
+  ".webp",
+  ".bmp",
+  ".ico",
+  ".cur",
+  ".tif",
+  ".tiff",
+];
 
 export function isBase64Url(url: string) {
   return url.startsWith("data:");
@@ -35,21 +32,21 @@ export function getFilenameAndExtensionFromUrl(url: string) {
     };
   } else {
     return {
-      fileName: "",
-      extension: "",
+      fileName: undefined,
+      extension: undefined,
     };
   }
 }
 
-export function getMimeTypeFromUrl(url: string) {
+export function isImageType(url: string) {
   if (isBase64Url(url)) {
-    return url.split(":")[1].split(";")[0];
+    return url.split(":")[1].split(";")[0].includes("image");
   } else {
     const { extension } = getFilenameAndExtensionFromUrl(url);
     if (!!extension) {
-      return extension.replace(".", "");
+      return SUPPORTED_IMG_EXTENSIONS.includes(extension);
     } else {
-      return undefined;
+      return false;
     }
   }
 }

--- a/packages/next-admin/src/utils/file.ts
+++ b/packages/next-admin/src/utils/file.ts
@@ -1,56 +1,70 @@
 const SUPPORTED_IMG_EXTENSIONS = [
-  ".apng",
-  ".avif",
-  ".png",
-  ".gif",
-  ".jpg",
-  ".jpeg",
-  ".jfif",
-  ".pjpeg",
-  ".pjp",
-  ".png",
-  ".svg",
-  ".webp",
-  ".bmp",
-  ".ico",
-  ".cur",
-  ".tif",
-  ".tiff",
+  "apng",
+  "avif",
+  "png",
+  "gif",
+  "jpg",
+  "jpeg",
+  "jfif",
+  "pjpeg",
+  "pjp",
+  "png",
+  "svg",
+  "webp",
+  "bmp",
+  "ico",
+  "cur",
+  "tif",
+  "tiff",
 ];
 
+/**
+ * Check if the url is a base64 url
+ */
 export function isBase64Url(url: string) {
   return url.startsWith("data:");
 }
 
+/*
+ * Get the filename and extension from a file url, does not work with base64 urls.
+ */
 export function getFilenameAndExtensionFromUrl(url: string) {
-  const regex = /([\w-]+)(\.[\w-]+)+(?!.*\/)/gm;
-  const match = regex.exec(url);
-  if (match && match.length > 2) {
-    return {
-      fileName: `${match[1]}${match[2]}`,
-      extension: match[2],
-    };
-  } else {
+  const cleanUrl = url.split("?")[0].split("#")[0];
+  const fullFilename = cleanUrl.split("/").pop();
+  if (!fullFilename) {
     return {
       fileName: undefined,
       extension: undefined,
     };
   }
+  const [_, extension] = fullFilename.split(".");
+
+  return {
+    fileName: fullFilename,
+    extension,
+  };
 }
 
+/**
+ * Check if the url points to a file of type image
+ */
 export function isImageType(url: string) {
   if (isBase64Url(url)) {
     return url.split(":")[1].split(";")[0].includes("image");
   } else {
     const { extension } = getFilenameAndExtensionFromUrl(url);
+    console.log("extension", extension);
     if (!!extension) {
-      return SUPPORTED_IMG_EXTENSIONS.includes(extension);
+      return SUPPORTED_IMG_EXTENSIONS.includes(extension.toLocaleLowerCase());
     } else {
       return false;
     }
   }
 }
 
+/**
+ * Get the filename from a file url
+*/  
 export function getFilenameFromUrl(url: string) {
   if (isBase64Url(url)) {
     return undefined;


### PR DESCRIPTION
## Title
Fetching image in `<FileWidget/>` component could cause CORS errors

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This PR changes the file detection behaviour in the `<FileWidget/>` component. 
We don't use `fetch` anymore. We detect the type of the file (image or other type of file) and the name via the URL of the file.

## Testing

Added test for each new utils/file.ts functions created

## Impact
No particular impact but it is important to mention that we don't handle the case where the image is hosted on a URL that doesn't directly point to a file (ex: `http://site/image.png`). So `http://site/image?w=300&h=300` would not work.

## Additional Changes
Updated e2e.yml to fix a GH actions error
