### PR TITLE
Removes warning "You're using next/head inside the app directory" and Feature to add css classes to sidebar group title

### DIFF
--- a/.changeset/rotten-beds-allow.md
+++ b/.changeset/rotten-beds-allow.md
@@ -1,0 +1,6 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+1. Avoid importing Head in app router project
+2. Allow to change styles of sidebar group title

--- a/apps/docs/pages/docs/api/options.mdx
+++ b/apps/docs/pages/docs/api/options.mdx
@@ -34,6 +34,7 @@ export const options: NextAdminOptions = {
     groups: [
       {
         title: "Users",
+        className: " bg-green-600 p-2 rounded-md", // group title extra classes. (optional)
         models: ["User"],
       },
       {

--- a/packages/next-admin/src/components/Menu.tsx
+++ b/packages/next-admin/src/components/Menu.tsx
@@ -258,7 +258,7 @@ export default function Menu({
             <ul role="list" className="flex flex-1 flex-col gap-y-4">
               {configuration?.groups?.map((group) => (
                 <li key={group.title}>
-                  <div className="text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color mb-2 text-xs uppercase tracking-wider">
+                  <div className={clsx("text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color mb-2 text-xs uppercase tracking-wider", group.className)}>
                     {group.title}
                   </div>
                   <ul role="list" className="-ml-2 mt-1 flex flex-col gap-y-1">

--- a/packages/next-admin/src/components/NextAdmin.tsx
+++ b/packages/next-admin/src/components/NextAdmin.tsx
@@ -1,4 +1,4 @@
-import Head from "next/head";
+import dynamic from 'next/dynamic'
 import { AdminComponentProps, CustomUIProps } from "../types";
 import { getSchemaForResource } from "../utils/jsonSchema";
 import { getCustomInputs } from "../utils/options";
@@ -7,6 +7,8 @@ import Form from "./Form";
 import List from "./List";
 import { MainLayout } from "./MainLayout";
 import PageLoader from "./PageLoader";
+
+const Head = dynamic(() => import('next/head'));
 
 // Components
 export function NextAdmin({

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -427,6 +427,10 @@ export type ModelOptions<T extends ModelName> = {
 
 export type SidebarGroup = {
   /**
+   * Some optional css classes to improve appearance of group title.
+   */
+    className?: string;
+  /**
    * the name of the group.
    */
   title: string;


### PR DESCRIPTION
## Title

[Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"]

## Type of Change

- [X] New feature
- [X] Bug fix
- [X] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [X] UI/UX improvement

## Issue

#380 
#381 

## Description

1. Having warning in terminal is always disturbing. This warning could be easily removed by just importing it dynamically.
2. In admin panel sidebar it was hard to differentiate between group title and model name. Allowing user to add custom css classes will make group title more easily recognizable.

## Screenshots

![Screenshot from 2024-08-14 11-14-33](https://github.com/user-attachments/assets/b68295c9-69cf-4822-9b32-e09706ce36e8)


## Testing

Nothing added

## Impact

1. There will be no warning
2. User will be able to customize looks of group title in sidebar

## Additional Information

Nothing
