### PR TITLE
feat: add support for scalar array

### DIFF
--- a/.changeset/curly-penguins-explode.md
+++ b/.changeset/curly-penguins-explode.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+add support to arrays of enums

--- a/.changeset/stupid-suits-report.md
+++ b/.changeset/stupid-suits-report.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+feat: add support for scalar array (#322)

--- a/apps/docs/pages/docs/i18n.mdx
+++ b/apps/docs/pages/docs/i18n.mdx
@@ -10,133 +10,173 @@ import OptionsTable from "../../components/OptionsTable";
 Next Admin supports i18n with the `translations` prop of the `NextAdmin` component.
 
 The following keys are accepted:
+
 <OptionsTable
-      options={[
-        {
-          name: 'list.header.add.label',
-          description: 'The "Add" button in the list header',
-          defaultValue: '"Add"',
-        },
-        {
-          name: 'list.header.search.placeholder',
-          description: 'The placeholder used in the search input',
-          defaultValue: '"Search"',
-        },
-        {
-          name: 'list.footer.indicator.showing',
-          description: <>The "Showing from" text in the list indicator, e.g: <u>Showing from</u> 1 to 10 of 25</>,
-            defaultValue: '"Showing from"',
-          },
-          {
-            name: 'list.footer.indicator.to',
-            description: <>The "to" text in the list indicator, e.g: Showing from 1 <u>to</u> 10 of 25</>,
-            defaultValue: '"to"',
-          },
-          {
-            name: 'list.footer.indicator.of',
-            description: <>The "of" text in the list indicator, e.g: Showing from 1 to 10 <u>of</u> 25</>,
-            defaultValue: '"of"',
-          },
-          {
-            name: 'list.row.actions.delete.label',
-            description: 'The text in the delete button displayed at the end of each row',
-            defaultValue: '"Delete"',
-          },
-          {
-            name: 'list.row.actions.delete.alert',
-            description: 'The text in the native alert when the delete action is called in the list',
-            defaultValue: '"Are you sure you want to delete {{count}} element(s)?"',
-          },
-          {
-            name: 'list.row.actions.delete.success',
-            description: 'The text appearing after a successful deletion from the list',
-            defaultValue: '"Deleted successfully"',
-          },
-          {
-            name: 'list.row.actions.delete.error',
-            description: 'The text appearing after an error during the deletion from the list',
-            defaultValue: '"An error occured while deleting"',
-          },
-          {
-            name: 'list.empty.label',
-            description: 'The text displayed when there is no row in the list',
-            defaultValue: '"No {{resource}} found"',
-          },
-          {
-            name: 'list.empty.caption',
-            description: 'The caption displayed when there is no row in the list',
-            defaultValue: '"Get started by creating a new {{resource}}"',
-          },
-          {
-            name: 'form.button.save.label',
-            description: 'The text displayed in the form submit button',
-            defaultValue: '"Submit"',
-          },
-          {
-            name: 'form.button.delete.label',
-            description: 'The text displayed in the form delete button',
-            defaultValue: '"Delete"',
-          },
-          {
-            name: 'form.delete.alert',
-            description: 'The text displayed on the alert when the delete button is clicked',
-            defaultValue: '"Are you sure you want to delete this?"',
-          },
-          {
-            name: 'form.widgets.file_upload.label',
-            description: 'The text displayed in file upload widget to select a file',
-            defaultValue: '"Choose a file"',
-          },
-          {
-            name: 'form.widgets.file_upload.drag_and_drop',
-            description: 'The text displayed in file upload widget to indicate a drag & drop is possible',
-            defaultValue: '"or drag and drop"',
-          },
-          {
-            name: 'form.widgets.file_upload.delete',
-            description: 'The text displayed in file upload widget to delete the current file',
-            defaultValue: '"Delete"',
-          },
-          {
-            name: 'form.widgets.multiselect.select',
-            description: 'The text displayed in the multiselect widget in list display mode to toggle the select dialog',
-            defaultValue: '"Select items"',
-          },
-          {
-            name: 'actions.label',
-            description: 'The text displayed in the dropdown button for the actions list',
-            defaultValue: '"Action"',
-          },
-          {
-            name: 'actions.edit.label',
-            description: 'The text displayed for the default edit action in the actions dropdown',
-            defaultValue: '"Edit"',
-          },
-          {
-            name: 'actions.create.label',
-            description: 'The text displayed for the default create action in the actions dropdown',
-            defaultValue: '"Create"',
-          },
-          {
-            name: 'actions.delete.label',
-            description: 'The text displayed for the default delete action in the actions dropdown',
-            defaultValue: '"Delete"',
-          },
-          {
-            name: 'selector.loading',
-            description: 'The text displayed in the selector widget while loading the options',
-            defaultValue: '"Loading..."',
-          },
-          {
-            name: 'user.logout',
-            description: 'The text displayed in the logout button',
-            defaultValue: '"Logout"',
-          },
-        {
-          name: 'model',
-          description: <>Object to custom model and fields names (<a href="#translate-model-name-and-fields">more details</a>).</>,
-          defaultValue: '{}',
-        },
+  options={[
+    {
+      name: "list.header.add.label",
+      description: 'The "Add" button in the list header',
+      defaultValue: '"Add"',
+    },
+    {
+      name: "list.header.search.placeholder",
+      description: "The placeholder used in the search input",
+      defaultValue: '"Search"',
+    },
+    {
+      name: "list.footer.indicator.showing",
+      description: (
+        <>
+          The "Showing from" text in the list indicator, e.g:{" "}
+          <u>Showing from</u> 1 to 10 of 25
+        </>
+      ),
+      defaultValue: '"Showing from"',
+    },
+    {
+      name: "list.footer.indicator.to",
+      description: (
+        <>
+          The "to" text in the list indicator, e.g: Showing from 1 <u>to</u> 10
+          of 25
+        </>
+      ),
+      defaultValue: '"to"',
+    },
+    {
+      name: "list.footer.indicator.of",
+      description: (
+        <>
+          The "of" text in the list indicator, e.g: Showing from 1 to 10{" "}
+          <u>of</u> 25
+        </>
+      ),
+      defaultValue: '"of"',
+    },
+    {
+      name: "list.row.actions.delete.label",
+      description:
+        "The text in the delete button displayed at the end of each row",
+      defaultValue: '"Delete"',
+    },
+    {
+      name: "list.row.actions.delete.alert",
+      description:
+        "The text in the native alert when the delete action is called in the list",
+      defaultValue: '"Are you sure you want to delete {{count}} element(s)?"',
+    },
+    {
+      name: "list.row.actions.delete.success",
+      description:
+        "The text appearing after a successful deletion from the list",
+      defaultValue: '"Deleted successfully"',
+    },
+    {
+      name: "list.row.actions.delete.error",
+      description:
+        "The text appearing after an error during the deletion from the list",
+      defaultValue: '"An error occured while deleting"',
+    },
+    {
+      name: "list.empty.label",
+      description: "The text displayed when there is no row in the list",
+      defaultValue: '"No {{resource}} found"',
+    },
+    {
+      name: "list.empty.caption",
+      description: "The caption displayed when there is no row in the list",
+      defaultValue: '"Get started by creating a new {{resource}}"',
+    },
+    {
+      name: "form.button.save.label",
+      description: "The text displayed in the form submit button",
+      defaultValue: '"Submit"',
+    },
+    {
+      name: "form.button.delete.label",
+      description: "The text displayed in the form delete button",
+      defaultValue: '"Delete"',
+    },
+    {
+      name: "form.delete.alert",
+      description:
+        "The text displayed on the alert when the delete button is clicked",
+      defaultValue: '"Are you sure you want to delete this?"',
+    },
+    {
+      name: "form.widgets.file_upload.label",
+      description: "The text displayed in file upload widget to select a file",
+      defaultValue: '"Choose a file"',
+    },
+    {
+      name: "form.widgets.file_upload.drag_and_drop",
+      description:
+        "The text displayed in file upload widget to indicate a drag & drop is possible",
+      defaultValue: '"or drag and drop"',
+    },
+    {
+      name: "form.widgets.file_upload.delete",
+      description:
+        "The text displayed in file upload widget to delete the current file",
+      defaultValue: '"Delete"',
+    },
+    {
+      name: "form.widgets.multiselect.select",
+      description:
+        "The text displayed in the multiselect widget in list display mode to toggle the select dialog",
+      defaultValue: '"Select items"',
+    },
+    {
+      name: "form.widgets.scalar_array.add",
+      description:
+        "The text displayed in the scalar array field's button to add new items to the array",
+      defaultValue: '"Add new item"',
+    },
+    {
+      name: "actions.label",
+      description:
+        "The text displayed in the dropdown button for the actions list",
+      defaultValue: '"Action"',
+    },
+    {
+      name: "actions.edit.label",
+      description:
+        "The text displayed for the default edit action in the actions dropdown",
+      defaultValue: '"Edit"',
+    },
+    {
+      name: "actions.create.label",
+      description:
+        "The text displayed for the default create action in the actions dropdown",
+      defaultValue: '"Create"',
+    },
+    {
+      name: "actions.delete.label",
+      description:
+        "The text displayed for the default delete action in the actions dropdown",
+      defaultValue: '"Delete"',
+    },
+    {
+      name: "selector.loading",
+      description:
+        "The text displayed in the selector widget while loading the options",
+      defaultValue: '"Loading..."',
+    },
+    {
+      name: "user.logout",
+      description: "The text displayed in the logout button",
+      defaultValue: '"Logout"',
+    },
+    {
+      name: "model",
+      description: (
+        <>
+          Object to custom model and fields names (
+          <a href="#translate-model-name-and-fields">more details</a>).
+        </>
+      ),
+      defaultValue: "{}",
+    },
   ]}
 />
 
@@ -145,7 +185,9 @@ The following keys are accepted:
 There are two ways to translate these default keys, provide a function named `getMessages` inside the options or provide `translations` props to `NextAdmin` component.
 
 <Callout type="info">
-  Using `getMessages` allows you to provide an object with a multiple level structure to translate the keys, while the `translations` props only allow you to provide a flat object (`form.widgets.file_upload.delete` ex.)
+  Using `getMessages` allows you to provide an object with a multiple level
+  structure to translate the keys, while the `translations` props only allow you
+  to provide a flat object (`form.widgets.file_upload.delete` ex.)
 </Callout>
 
 You can also pass your own set of translations. For example you can set a custom action name as a translation key, which will then be translated by the lib.
@@ -195,5 +237,7 @@ By using the `model` key in the translations object, you can translate the model
 ```
 
 <Callout type="info">
-  If you only use one language for your admin, you should prefer to use the `alias` system ([more details](/docs/api/model-configuration)) to customize field names.
+  If you only use one language for your admin, you should prefer to use the
+  `alias` system ([more details](/docs/api/model-configuration)) to customize
+  field names.
 </Callout>

--- a/apps/example/e2e/utils.ts
+++ b/apps/example/e2e/utils.ts
@@ -111,6 +111,10 @@ export const fillForm = async (
         'input[id="author-search"]',
         dataTest.Post.author.slice(0, 6)
       );
+
+      await page.waitForTimeout(2000);
+      await page.getByText(dataTest.Post.author).click();
+
       const hasTags = await page.isVisible(
         'input[name="tags"] ~ li:first-of-type'
       );
@@ -123,8 +127,6 @@ export const fillForm = async (
         );
       }
 
-      await page.waitForTimeout(2000);
-      await page.getByText(dataTest.Post.author).click();
       break;
     }
     case "Category":

--- a/apps/example/e2e/utils.ts
+++ b/apps/example/e2e/utils.ts
@@ -19,6 +19,7 @@ export const dataTest: DataTest = {
   Post: {
     title: "MY_POST",
     author: "User 0 (user0@nextadmin.io)",
+    tag: "Tag test",
   },
   Category: {
     name: "MY_CATEGORY",
@@ -33,6 +34,7 @@ const dataTestUpdate: DataTest = {
   Post: {
     title: "UPDATE_MY_POST",
     author: "User 1 (user1@nextadmin.io)",
+    tag: "Tag test",
   },
   Category: {
     name: "UPDATE_MY_CATEGORY",
@@ -101,7 +103,7 @@ export const fillForm = async (
         buffer: Buffer.from("test"),
       });
       break;
-    case "Post":
+    case "Post": {
       await page.fill('input[id="title"]', dataTest.Post.title);
       await page.click('select[name="author"]');
       /* Search for relationship test */
@@ -109,9 +111,22 @@ export const fillForm = async (
         'input[id="author-search"]',
         dataTest.Post.author.slice(0, 6)
       );
+      const hasTags = await page.isVisible(
+        'input[name="tags"] ~ li:first-of-type'
+      );
+
+      if (!hasTags) {
+        await page.click('input[name="tags"] ~ button');
+        await page.fill(
+          'input[name="tags"] ~ li:first-of-type input',
+          dataTest.Post.tag
+        );
+      }
+
       await page.waitForTimeout(2000);
       await page.getByText(dataTest.Post.author).click();
       break;
+    }
     case "Category":
       await page.fill('input[id="name"]', dataTest.Category.name);
       break;
@@ -146,6 +161,10 @@ export const readForm = async (
       expect(await page.innerText('span[id="author"]')).toBe(
         dataTest.Post.author
       );
+      const tagInput = page.locator(
+        "input[name='tags'] ~ li:first-of-type input"
+      );
+      expect(await tagInput.inputValue()).toBe(dataTest.Post.tag);
       break;
     case "Category":
       expect(await page.inputValue('input[id="name"]')).toBe(

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -146,8 +146,16 @@ export const options: NextAdminOptions = {
           { format: "CSV", url: "/api/posts/export?format=csv" },
           { format: "JSON", url: "/api/posts/export?format=json" },
         ],
-        display: ["id", "title", "published", "author", "categories", "rate"],
-        search: ["title", "content"],
+        display: [
+          "id",
+          "title",
+          "published",
+          "author",
+          "categories",
+          "rate",
+          "tags",
+        ],
+        search: ["title", "content", "tags"],
         fields: {
           author: {
             formatter: (author) => {
@@ -183,6 +191,7 @@ export const options: NextAdminOptions = {
           "categories",
           "author",
           "rate",
+          "tags",
         ],
       },
     },

--- a/apps/example/pageRouterOptions.tsx
+++ b/apps/example/pageRouterOptions.tsx
@@ -100,8 +100,8 @@ export const options: NextAdminOptions = {
       title: "Posts",
       icon: "NewspaperIcon",
       list: {
-        display: ["id", "title", "published", "author", "categories"],
-        search: ["title"],
+        display: ["id", "title", "published", "author", "categories", "tags"],
+        search: ["title", "tags"],
         fields: {
           author: {
             formatter: (author) => {
@@ -123,6 +123,7 @@ export const options: NextAdminOptions = {
           "published",
           "author",
           "categories",
+          "tags",
         ],
         fields: {
           content: {

--- a/apps/example/prisma/json-schema/json-schema.json
+++ b/apps/example/prisma/json-schema/json-schema.json
@@ -113,11 +113,18 @@
         "order": {
           "type": "integer",
           "default": 0
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [
         "title",
-        "authorId"
+        "authorId",
+        "tags"
       ]
     },
     "Profile": {

--- a/apps/example/prisma/migrations/20240902093202_tags_on_post/migration.sql
+++ b/apps/example/prisma/migrations/20240902093202_tags_on_post/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "tags" TEXT[];

--- a/apps/example/prisma/schema.prisma
+++ b/apps/example/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Post {
   categories CategoriesOnPosts[]
   rate       Decimal?            @db.Decimal(5, 2)
   order      Int                 @default(0)
+  tags       String[]
 }
 
 model Profile {

--- a/packages/next-admin/src/components/Form.tsx
+++ b/packages/next-admin/src/components/Form.tsx
@@ -64,6 +64,7 @@ import {
   TooltipRoot,
   TooltipTrigger,
 } from "./radix/Tooltip";
+import BaseInput from "./inputs/BaseInput";
 
 const RichTextField = dynamic(() => import("./inputs/RichText/RichTextField"), {
   ssr: false,
@@ -450,7 +451,7 @@ const Form = ({
       if (["time", "time-second"].includes(schema?.format as string)) {
         return (
           // @ts-expect-error
-          <input
+          <BaseInput
             type="time"
             onChange={onChangeOverride || onTextChange}
             {...props}
@@ -460,24 +461,18 @@ const Form = ({
                 .slice(0, schema?.format === "time-second" ? 3 : 2)
                 .join(":") ?? ""
             }
-            className={clsx(
-              "dark:bg-dark-nextadmin-background-subtle text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted ring-nextadmin-border-default focus:ring-nextadmin-brand-default dark:focus:ring-dark-nextadmin-brand-default dark:ring-dark-nextadmin-border-strong block w-full rounded-md border-0 px-2 py-1.5 text-sm shadow-sm ring-1 ring-inset transition-colors duration-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:leading-6",
-              { "ring-red-600 dark:ring-red-400": rawErrors }
-            )}
+            className={clsx({ "ring-red-600 dark:ring-red-400": rawErrors })}
             step={schema?.format === "time-second" ? 1 : undefined}
           />
         );
       }
       return (
         // @ts-expect-error
-        <input
+        <BaseInput
           onChange={onChangeOverride || onTextChange}
           {...props}
           value={props.value ?? ""}
-          className={clsx(
-            "dark:bg-dark-nextadmin-background-subtle text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted ring-nextadmin-border-default focus:ring-nextadmin-brand-default dark:focus:ring-dark-nextadmin-brand-default dark:ring-dark-nextadmin-border-strong block w-full rounded-md border-0 px-2 py-1.5 text-sm shadow-sm ring-1 ring-inset transition-colors duration-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:leading-6",
-            { "ring-red-600 dark:ring-red-400": rawErrors }
-          )}
+          className={clsx({ "ring-red-600 dark:ring-red-400": rawErrors })}
         />
       );
     },
@@ -550,7 +545,7 @@ const Form = ({
             extraErrors={extraErrors}
             fields={fields}
             disabled={allDisabled}
-            formContext={{ isPending }}
+            formContext={{ isPending, dmmfSchema }}
             templates={{
               ...templates,
               ButtonTemplates: { SubmitButton: submitButton },

--- a/packages/next-admin/src/components/inputs/ArrayField.tsx
+++ b/packages/next-admin/src/components/inputs/ArrayField.tsx
@@ -1,8 +1,28 @@
 import { FieldProps } from "@rjsf/utils";
 import MultiSelectWidget from "./MultiSelect/MultiSelectWidget";
+import ScalarArrayField from "./ScalarArray/ScalarArrayField";
+import type { FormProps } from "../../types";
 
 const ArrayField = (props: FieldProps) => {
-  const { formData, onChange, name, disabled, schema, required } = props;
+  const { formData, onChange, name, disabled, schema, required, formContext } =
+    props;
+
+  const dmmfSchema = formContext.dmmfSchema as FormProps["dmmfSchema"];
+
+  const dmmfField = dmmfSchema.find((field) => field.name === name);
+
+  if (dmmfField?.kind === "scalar" && dmmfField?.isList) {
+    return (
+      <ScalarArrayField
+        name={name}
+        formData={formData}
+        onChange={onChange}
+        disabled={disabled ?? false}
+        schema={schema}
+      />
+    );
+  }
+
   return (
     <MultiSelectWidget
       onChange={onChange}

--- a/packages/next-admin/src/components/inputs/ArrayField.tsx
+++ b/packages/next-admin/src/components/inputs/ArrayField.tsx
@@ -1,7 +1,7 @@
 import { FieldProps } from "@rjsf/utils";
 import MultiSelectWidget from "./MultiSelect/MultiSelectWidget";
 import ScalarArrayField from "./ScalarArray/ScalarArrayField";
-import type { FormProps } from "../../types";
+import type { Enumeration, FormProps } from "../../types";
 
 const ArrayField = (props: FieldProps) => {
   const { formData, onChange, name, disabled, schema, required, formContext } =
@@ -23,6 +23,9 @@ const ArrayField = (props: FieldProps) => {
     );
   }
 
+  const options =
+    dmmfField?.kind === "enum" ? (schema.enum as Enumeration[]) : undefined;
+
   return (
     <MultiSelectWidget
       onChange={onChange}
@@ -31,6 +34,7 @@ const ArrayField = (props: FieldProps) => {
       disabled={disabled ?? false}
       required={required}
       schema={schema}
+      options={options}
     />
   );
 };

--- a/packages/next-admin/src/components/inputs/BaseInput.tsx
+++ b/packages/next-admin/src/components/inputs/BaseInput.tsx
@@ -1,0 +1,21 @@
+import clsx from "clsx";
+import { ComponentProps } from "react";
+import { twMerge } from "tailwind-merge";
+
+type Props = ComponentProps<"input">;
+
+const BaseInput = ({ className, ...props }: Props) => {
+  return (
+    <input
+      className={twMerge(
+        clsx(
+          "dark:bg-dark-nextadmin-background-subtle text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted ring-nextadmin-border-default focus:ring-nextadmin-brand-default dark:focus:ring-dark-nextadmin-brand-default dark:ring-dark-nextadmin-border-strong block w-full rounded-md border-0 px-2 py-1.5 text-sm shadow-sm ring-1 ring-inset transition-colors duration-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:leading-6",
+          className
+        )
+      )}
+      {...props}
+    />
+  );
+};
+
+export default BaseInput;

--- a/packages/next-admin/src/components/inputs/DndItem.tsx
+++ b/packages/next-admin/src/components/inputs/DndItem.tsx
@@ -1,0 +1,86 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  ArrowTopRightOnSquareIcon,
+  Bars2Icon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import clsx from "clsx";
+import Link from "next/link";
+import { ReactElement } from "react";
+
+type Props = {
+  label: string | ReactElement;
+  deletable?: boolean;
+  sortable?: boolean;
+  onRemoveClick: () => void;
+  href?: string;
+  value: string;
+};
+
+const DndItem = ({
+  label,
+  deletable,
+  sortable,
+  onRemoveClick,
+  href,
+  value,
+}: Props) => {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    setActivatorNodeRef,
+  } = useSortable({ id: value });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <li
+      className={clsx(
+        "ring-nextadmin-border-default dark:ring-dark-nextadmin-border-strong bg-nextadmin-background-default dark:bg-dark-nextadmin-background-subtle relative flex w-full cursor-default justify-between gap-2 rounded-md px-3 py-2 text-sm placeholder-gray-500 shadow-sm ring-1",
+        !deletable && "cursor-not-allowed opacity-50"
+      )}
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      aria-describedby="sortable-list"
+    >
+      <div className="flex flex-1 items-center gap-2">
+        {sortable && (
+          <div
+            ref={setActivatorNodeRef}
+            className={clsx({
+              "cursor-grab active:cursor-grabbing": sortable,
+            })}
+            {...listeners}
+          >
+            <Bars2Icon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-4 w-4" />
+          </div>
+        )}
+        {label}
+      </div>
+      {(href || deletable) && (
+        <div className="flex items-center space-x-3">
+          {!!href && (
+            <Link href={href} className="flex items-center">
+              <ArrowTopRightOnSquareIcon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-5 w-5 cursor-pointer" />
+            </Link>
+          )}
+          {deletable && (
+            <div onClick={() => onRemoveClick()}>
+              <XMarkIcon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-5 w-5 cursor-pointer" />
+            </div>
+          )}
+        </div>
+      )}
+    </li>
+  );
+};
+
+export default DndItem;

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayListItem.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayListItem.tsx
@@ -1,16 +1,8 @@
-import { useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
-import {
-  ArrowTopRightOnSquareIcon,
-  Bars2Icon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline";
 import { RJSFSchema } from "@rjsf/utils";
-import clsx from "clsx";
-import Link from "next/link";
 import { useConfig } from "../../../context/ConfigContext";
 import { Enumeration } from "../../../types";
 import { slugify } from "../../../utils/tools";
+import DndItem from "../DndItem";
 
 type Props = {
   item: Enumeration;
@@ -29,63 +21,20 @@ const MultiSelectDisplayListItem = ({
 }: Props) => {
   const { basePath } = useConfig();
   const { value, label } = item;
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    setActivatorNodeRef,
-  } = useSortable({ id: item.value });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
 
   return (
-    <li
-      className={clsx(
-        "ring-nextadmin-border-default dark:ring-dark-nextadmin-border-strong bg-nextadmin-background-default dark:bg-dark-nextadmin-background-subtle relative flex w-full cursor-default justify-between rounded-md px-3 py-2 text-sm placeholder-gray-500 shadow-sm ring-1",
-        !deletable && "cursor-not-allowed opacity-50"
-      )}
-      ref={setNodeRef}
-      style={style}
-      {...attributes}
-      aria-describedby="sortable-list"
-    >
-      <div className="flex items-center gap-2">
-        {sortable && (
-          <div
-            ref={setActivatorNodeRef}
-            className={clsx({
-              "cursor-grab active:cursor-grabbing": sortable,
-            })}
-            {...listeners}
-          >
-            <Bars2Icon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-4 w-4" />
-          </div>
-        )}
-        {label}
-      </div>
-      <div className="flex items-center space-x-3">
-        <Link
-          href={`${basePath}/${slugify(
-            item?.data?.modelName ??
-              // @ts-expect-error
-              schema.items?.relation
-          )}/${value}`}
-          className="flex items-center"
-        >
-          <ArrowTopRightOnSquareIcon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-5 w-5 cursor-pointer" />
-        </Link>
-        {deletable && (
-          <div onClick={() => onRemoveClick(value)}>
-            <XMarkIcon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-5 w-5 cursor-pointer" />
-          </div>
-        )}
-      </div>
-    </li>
+    <DndItem
+      sortable={sortable}
+      deletable={deletable}
+      value={item.value}
+      label={label}
+      onRemoveClick={() => onRemoveClick(value)}
+      href={`${basePath}/${slugify(
+        item?.data?.modelName ??
+          // @ts-expect-error
+          schema.items?.relation
+      )}/${value}`}
+    />
   );
 };
 

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayListItem.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayListItem.tsx
@@ -22,6 +22,9 @@ const MultiSelectDisplayListItem = ({
   const { basePath } = useConfig();
   const { value, label } = item;
 
+  // @ts-expect-error
+  const relationModel = item?.data?.modelName ?? schema.items?.relation;
+
   return (
     <DndItem
       sortable={sortable}
@@ -29,11 +32,11 @@ const MultiSelectDisplayListItem = ({
       value={item.value}
       label={label}
       onRemoveClick={() => onRemoveClick(value)}
-      href={`${basePath}/${slugify(
-        item?.data?.modelName ??
-          // @ts-expect-error
-          schema.items?.relation
-      )}/${value}`}
+      href={
+        relationModel
+          ? `${basePath}/${slugify(relationModel)}/${value}`
+          : undefined
+      }
     />
   );
 };

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectItem.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectItem.tsx
@@ -20,17 +20,18 @@ const MultiSelectItem = ({
 }: Props) => {
   const { basePath } = useConfig();
 
+  // @ts-expect-error
+  const relationModel = item?.data?.modelName ?? schema.items?.relation;
+
   return (
     <div className="py border-nextadmin-border-default dark:border-dark-nextadmin-border-strong text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted dark:hover:bg-dark-nextadmin-background-muted/50 hover:bg-nextadmin-background-muted relative z-10 flex cursor-default items-center justify-center rounded-md border px-2 text-sm">
-      <Link
-        href={`${basePath}/${slugify(
-          item?.data?.modelName ??
-            // @ts-expect-error
-            schema.items?.relation
-        )}/${item.value}`}
-      >
-        {item.label}
-      </Link>
+      {relationModel ? (
+        <Link href={`${basePath}/${slugify(relationModel)}/${item.value}`}>
+          {item.label}
+        </Link>
+      ) : (
+        item.label
+      )}
       {deletable && (
         <button
           type="button"

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectWidget.tsx
@@ -40,18 +40,14 @@ const MultiSelectWidget = (props: Props) => {
 
   const selectedValues = formData?.map((item: any) => item?.value) ?? [];
 
-  const optionsLeft = options?.filter(
-    (option) =>
-      !formData?.find((item: Enumeration) => item.value === option.value)
-  );
-
   const displayMode =
     !!fieldOptions && "display" in fieldOptions
       ? fieldOptions.display ?? "select"
       : "select";
 
-  // @ts-expect-error
-  const fieldSortable = displayMode === "list" && !!fieldOptions?.orderField;
+  const fieldSortable =
+    // @ts-expect-error
+    displayMode === "list" && (!!fieldOptions?.orderField || !!schema.enum);
 
   const select = (
     <select
@@ -159,7 +155,7 @@ const MultiSelectWidget = (props: Props) => {
         ref={containerRef}
         open={isOpen}
         name={name}
-        options={optionsLeft?.length ? optionsLeft : undefined}
+        options={options?.length ? options : undefined}
         onChange={(option: Enumeration) => {
           setFieldDirty(name);
           onChange([...(formData || []), option]);

--- a/packages/next-admin/src/components/inputs/ScalarArray/ScalarArrayField.tsx
+++ b/packages/next-admin/src/components/inputs/ScalarArray/ScalarArrayField.tsx
@@ -1,0 +1,124 @@
+import { RJSFSchema } from "@rjsf/utils";
+import Button from "../../radix/Button";
+import { useI18n } from "../../../context/I18nContext";
+import { DndContext, DragEndEvent } from "@dnd-kit/core";
+import { SortableContext } from "@dnd-kit/sortable";
+import { useEffect, useState } from "react";
+import { useFormState } from "../../../context/FormStateContext";
+import ScalarArrayFieldItem from "./ScalarArrayFieldItem";
+import clsx from "clsx";
+
+type Scalar = number | string;
+
+type Props = {
+  formData: Scalar[];
+  onChange: (data: Scalar[]) => void;
+  name: string;
+  disabled: boolean;
+  schema: RJSFSchema;
+};
+
+const ScalarArrayField = ({
+  formData,
+  onChange,
+  name,
+  disabled,
+  schema,
+}: Props) => {
+  const { t } = useI18n();
+  const { setFieldDirty } = useFormState();
+  const [formDataList, setFormDataList] = useState(() =>
+    formData.map((value) => ({
+      id: crypto.randomUUID(),
+      value,
+    }))
+  );
+
+  const onDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+
+    if (active.id !== over?.id) {
+      const activeIndex = formDataList.findIndex(
+        (value) => value.id === active.id
+      );
+      const overIndex = formDataList.findIndex(
+        (value) => value.id === over?.id
+      );
+      const newFormData = [...formDataList];
+      newFormData.splice(overIndex, 0, newFormData.splice(activeIndex, 1)[0]);
+      setFieldDirty(name);
+      onChange(newFormData.map((val) => val.value));
+      setFormDataList(newFormData);
+    }
+  };
+
+  const renderList = () => {
+    return formDataList.map((value) => {
+      return (
+        <ScalarArrayFieldItem
+          key={value.id}
+          value={value.value.toString()}
+          onRemoveClick={() => {
+            setFormDataList((prev) =>
+              prev.filter((val) => val.id !== value.id)
+            );
+            setFieldDirty(name);
+          }}
+          inputValue={value.value.toString()}
+          disabled={disabled}
+          onChange={(newValue) => {
+            setFormDataList((prev) =>
+              prev.map((val) =>
+                val.id === value.id ? { ...val, value: newValue } : val
+              )
+            );
+            setFieldDirty(name);
+          }}
+          id={value.id}
+          // @ts-expect-error
+          scalarType={schema.items.type}
+        />
+      );
+    });
+  };
+
+  const onAddNewItem = () => {
+    setFormDataList((prev) => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        value: "",
+      },
+    ]);
+    setFieldDirty(name);
+  };
+
+  useEffect(() => {
+    onChange(formDataList.map((val) => val.value));
+  }, [formDataList]);
+
+  return (
+    <div className="relative flex flex-col gap-3">
+      <input
+        type="hidden"
+        name={name}
+        value={JSON.stringify(formDataList.map((val) => val.value))}
+      />
+      <DndContext onDragEnd={onDragEnd}>
+        <SortableContext items={formDataList.map((val) => val.id) ?? []}>
+          {renderList()}
+        </SortableContext>
+      </DndContext>
+      <Button
+        type="button"
+        className="w-fit"
+        disabled={disabled}
+        onClick={onAddNewItem}
+      >
+        {t("form.widgets.scalar_array.add")}
+      </Button>
+    </div>
+  );
+};
+
+export default ScalarArrayField;

--- a/packages/next-admin/src/components/inputs/ScalarArray/ScalarArrayFieldItem.tsx
+++ b/packages/next-admin/src/components/inputs/ScalarArray/ScalarArrayFieldItem.tsx
@@ -1,0 +1,45 @@
+import BaseInput from "../BaseInput";
+import DndItem from "../DndItem";
+
+type Props = {
+  value: string;
+  onChange: (value: string) => void;
+  disabled: boolean;
+  onRemoveClick: () => void;
+  inputValue: string;
+  id: string;
+  scalarType: string;
+};
+
+const ScalarArrayFieldItem = ({
+  value,
+  onChange,
+  disabled,
+  onRemoveClick,
+  id,
+  scalarType,
+}: Props) => {
+  const renderInput = () => {
+    return (
+      <BaseInput
+        value={value}
+        onChange={(evt) => onChange(evt.target.value)}
+        disabled={disabled}
+        className="w-full"
+        type={scalarType === "number" ? "number" : "text"}
+      />
+    );
+  };
+
+  return (
+    <DndItem
+      sortable={!disabled}
+      deletable={!disabled}
+      onRemoveClick={onRemoveClick}
+      label={renderInput()}
+      value={id}
+    />
+  );
+};
+
+export default ScalarArrayFieldItem;

--- a/packages/next-admin/src/i18n.ts
+++ b/packages/next-admin/src/i18n.ts
@@ -30,6 +30,7 @@ export const defaultTranslations: Translations = {
   "form.widgets.file_upload.drag_and_drop": "or drag and drop",
   "form.widgets.file_upload.delete": "Delete",
   "form.widgets.multiselect.select": "Select items",
+  "form.widgets.scalar_array.add": "Add new item",
   "selector.loading": "Loading...",
   "theme.dark": "Dark",
   "theme.light": "Light",

--- a/packages/next-admin/src/tests/prismaUtils.test.ts
+++ b/packages/next-admin/src/tests/prismaUtils.test.ts
@@ -15,6 +15,7 @@ describe("getMappedDataList", () => {
         authorId: 1,
         rate: new Decimal(5),
         order: 0,
+        tags: [],
       },
       {
         id: 2,
@@ -25,6 +26,7 @@ describe("getMappedDataList", () => {
         authorId: 1,
         rate: new Decimal(5),
         order: 1,
+        tags: [],
       },
     ];
 
@@ -61,6 +63,7 @@ describe("optionsFromResource", () => {
         authorId: 1,
         rate: new Decimal(5),
         order: 0,
+        tags: [],
       },
       {
         id: 2,
@@ -71,6 +74,7 @@ describe("optionsFromResource", () => {
         authorId: 1,
         rate: new Decimal(5),
         order: 1,
+        tags: [],
       },
     ];
 

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -10,6 +10,11 @@ declare type JSONSchema7Definition = JSONSchema7 & {
 };
 
 type OmitNever<T> = { [K in keyof T as T[K] extends never ? never : K]: T[K] };
+type ExtendsStringButIsNotString<T> = T extends string
+  ? string extends T
+    ? false
+    : true
+  : false;
 
 /** Type for Model */
 
@@ -220,7 +225,13 @@ export type EditFieldsOptions<T extends ModelName> = {
             }
           | { display?: "list"; orderField?: keyof ModelFromProperty<T, P> }
         )
-    : {});
+    : P extends keyof ScalarField<T>
+      ? ScalarField<T>[P] extends (infer Q)[]
+        ? ExtendsStringButIsNotString<Q> extends true
+          ? { display?: "list" | "select" }
+          : {}
+        : {}
+      : {});
 };
 
 export type Handler<
@@ -429,7 +440,7 @@ export type SidebarGroup = {
   /**
    * Some optional css classes to improve appearance of group title.
    */
-    className?: string;
+  className?: string;
   /**
    * the name of the group.
    */
@@ -834,7 +845,6 @@ export type CreateAppHandlerParams<P extends string = "nextadmin"> = {
    */
   schema: any;
 };
-
 
 export type FormProps = {
   data: any;

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -54,6 +54,18 @@ const createWherePredicate = (
               }
             }
 
+            if (field.kind === "scalar" && field.isList) {
+              if (field.type !== "String" && Number.isNaN(Number(search))) {
+                return null;
+              }
+
+              return {
+                [field.name]: {
+                  has: field.type === "String" ? search : Number(search),
+                },
+              };
+            }
+
             if (field.type === "String") {
               // @ts-ignore
               const mode = Prisma?.QueryMode

--- a/packages/next-admin/src/utils/props.ts
+++ b/packages/next-admin/src/utils/props.ts
@@ -210,7 +210,6 @@ export const getMainLayoutProps = ({
   options,
   params,
   isAppDir = true,
-  
 }: GetMainLayoutPropsParams): MainLayoutProps => {
   if (params !== undefined && !Array.isArray(params)) {
     throw new Error(

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -276,7 +276,14 @@ export const transformData = <M extends ModelName>(
     if (get) {
       acc[key] = get(data[key]);
     } else if (fieldKind === "enum") {
-      acc[key] = data[key] ? { label: data[key], value: data[key] } : null;
+      const value = data[key];
+      if (Array.isArray(value)) {
+        acc[key] = value.map((item) => {
+          return { label: item, value: item };
+        });
+      } else {
+        acc[key] = value ? { label: value, value } : null;
+      }
     } else if (fieldKind === "object") {
       const modelRelation = field!.type as ModelName;
       const modelRelationIdField = getModelIdProperty(modelRelation);
@@ -301,6 +308,7 @@ export const transformData = <M extends ModelName>(
           : modelRelation,
         options
       );
+
       if (Array.isArray(data[key])) {
         acc[key] = data[key].map((item: any) => {
           if (
@@ -409,7 +417,7 @@ export const findRelationInData = (
       }
     }
 
-    if (dmmfPropertyKind === "scalar" && dmmfProperty.isList) {
+    if (["scalar", "enum"].includes(dmmfPropertyKind) && dmmfProperty.isList) {
       data.forEach((item) => {
         if (item[dmmfPropertyName]) {
           item[dmmfPropertyName] = {
@@ -742,6 +750,7 @@ export const formattedFormData = async <M extends ModelName>(
           }
         } else if (dmmfPropertyKind === "scalar" && dmmfProperty.isList) {
           const dmmfPropertyName = dmmfProperty.name as keyof ScalarField<M>;
+
           const formDataValue = JSON.parse(formData[dmmfPropertyName]!) as
             | string[]
             | number[];
@@ -763,6 +772,13 @@ export const formattedFormData = async <M extends ModelName>(
               set: formDataValue,
             };
           }
+        } else if (dmmfPropertyKind === "enum" && dmmfProperty.isList) {
+          const dmmfPropertyName = dmmfProperty.name as keyof ScalarField<M>;
+
+          const data = JSON.parse(formData[dmmfPropertyName] ?? "[]");
+          formattedData[dmmfPropertyName] = {
+            set: data,
+          };
         } else {
           const dmmfPropertyName = dmmfProperty.name as keyof ScalarField<M>;
           if (formData[dmmfPropertyName] === "") {


### PR DESCRIPTION
## Title

Add support for Prisma scalar array 

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#322 

## Description

Add support for Prisma scalar arrays. Currently supported scalar types are strings and numbers.

In the list, the array is displayed as a count. The PR also includes support search inside the array (case sensitive & exact content as its the only supported way on Prisma)

## Screenshots

![image](https://github.com/user-attachments/assets/ca56e520-45d1-4078-bbbd-2960c854c60a)

![image](https://github.com/user-attachments/assets/b933535e-6f92-46f5-ab22-39f95dbf7e9c)

