### PR TITLE
feat: add hooks to model edition

### DIFF
--- a/.changeset/cool-cycles-do.md
+++ b/.changeset/cool-cycles-do.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+feat: add hooks to model edition (#386)

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -550,6 +550,28 @@ When you define a field, use the field's name as the key and the following objec
   ]}
 />
 
+### `edit.hooks` property
+
+The `hooks` property allows you to intercept the values of a form, before and after its insertion in the database.
+It is an object that can have the following properties:
+
+<OptionsTable
+  options={[
+    {
+      name: "beforeDb",
+      type: "Function",
+      description:
+        "a function that takes the form values, the insertion mode (create or edit) and the request object as parameters. It must return a promise with the form values. You can throw a [HookError]() in case of an error, which will cause an early return in the handler with the appropriate response status and error message.",
+    },
+    {
+      name: "afterDb",
+      type: "Function",
+      description:
+        "a function that takes the form values, the insertion mode (create or edit) and the request as parameters. It returns nothing.",
+    },
+  ]}
+/>
+
 ## `actions` property
 
 The `actions` property is an array of objects that allows you to define a set of actions that can be executed on one or more records of the resource. On the list view, there is a default action for deletion. The object can have the following properties:
@@ -729,6 +751,26 @@ Represents the props that are passed to the custom input component.
       name: "disabled",
       type: "Boolean",
       description: "boolean indicating if the field is disabled",
+    },
+  ]}
+/>
+
+## HookError
+
+The `HookError` is an error that can be thrown in the `beforeDb` hook of the `edit` property. It takes the following arguments in its constructor:
+
+<OptionsTable
+  options={[
+    {
+      name: "status",
+      type: "Number",
+      description: "the HTTP status code",
+    },
+    {
+      name: "data",
+      type: "Object",
+      description:
+        "an error object that must contain at least an error property which is a string",
     },
   ]}
 />

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -567,7 +567,7 @@ It is an object that can have the following properties:
       name: "afterDb",
       type: "Function",
       description:
-        "a function that takes the form values, the insertion mode (create or edit) and the request as parameters. It returns nothing.",
+        "a function that takes the insertion response, the insertion mode (create or edit) and the request as parameters. It returns the same data as the insertion response.",
     },
   ]}
 />

--- a/apps/docs/pages/docs/code-snippets.mdx
+++ b/apps/docs/pages/docs/code-snippets.mdx
@@ -204,45 +204,46 @@ There are two example files in the example project:
 - [app/api/users/export/route.ts](https://github.com/premieroctet/next-admin/tree/main/apps/example/app/api/users/export/route.ts)
 - [app/api/posts/export/route.ts](https://github.com/premieroctet/next-admin/tree/main/apps/example/app/api/posts/export/route.ts)
 
-## Add data to formData before submitting
+## Intercepting data submission
 
-If you want to add data to the form data before submitting it, you can add logic to the `submitFormAction` function. This is an example of how to add `createdBy` and `updatedBy` fields based on the user id:
+If you want to add data to the form data before submitting it, you can make use of the `edit.hooks` field of a model options. This is an example of how to add `createdBy` and `updatedBy` fields on a post based on the user id, and submit an email to inform the creation or edition of the post:
 
-```typescript copy filename="app/api/admin/[[...nextadmin]]/route.ts"
-import { options } from "@/options";
-import { prisma } from "@/prisma";
-import schema from "@/prisma/json-schema/json-schema.json";
-import { createHandler } from "@premieroctet/next-admin/dist/appHandler";
-import { NextRequest } from "next/server";
+```typescript copy"
+{
+  model: {
+    Post: {
+      edit: {
+        hooks: {
+          async beforeDb(data, mode, request) {
+            const userId = 1 // retrieve from the request / cookies, etc
 
-const { run } = createHandler({
-  apiBasePath: "/api/admin",
-  options,
-  prisma,
-  schema,
-});
+            // your own permission check
+            if (!userHasPermission(userId)) {
+              throw new HookError(403, { error: "Forbidden" });
+            }
 
-/**
- * context.params.nextadmin = ['{{model}}'] => CREATE
- * context.params.nextadmin = ['{{model}}', '{{id}}'] => UPDATE
- */
-export async function POST(req: NextRequest, context: any) {
-  const userId = 1;
+            if (mode === "create") {
+              data.createdBy = userId;
+            } else {
+              data.updatedBy = userId;
+            }
 
-  if (context.params.nextadmin.length === 1) {
-    const formData = await req.formData();
-    formData.append("createdBy", userId.toString());
-    req.formData = async () => formData;
-  } else {
-    const formData = await req.formData();
-    formData.append("updatedBy", userId.toString());
-    req.formData = async () => formData;
+            return data
+          },
+          async afterDb(data, mode, request) {
+            const userId = 1 // retrieve from the request / cookies, etc
+
+            sendMail({
+              to: "some@email.com",
+              subject: "Post updated",
+              text: `Post ${data.title} has been ${mode === "create" ? "created" : "updated"} by ${userId}`,
+            })
+          }
+        }
+      }
+    }
   }
-
-  return run(req, context);
 }
-
-export { run as DELETE, run as GET };
 ```
 
 > Note that this example assumes that you have a `createdBy` and `updatedBy` field on each model, if you need to check the model name, you can use `params.params[0]`.

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -207,8 +207,10 @@ export const options: NextAdminOptions = {
 
             return data;
           },
-          async afterDb(response, mode) {
-            console.log("intercept afterdb", response, mode);
+          async afterDb(response, mode, request) {
+            console.log("intercept afterdb", response, mode, request);
+
+            return response
           },
         },
       },

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -201,6 +201,16 @@ export const options: NextAdminOptions = {
           "rate",
           "tags",
         ],
+        hooks: {
+          async beforeDb(data, mode, request) {
+            console.log("intercept beforedb", data, mode, request);
+
+            return data;
+          },
+          async afterDb(response, mode) {
+            console.log("intercept afterdb", response, mode);
+          },
+        },
       },
     },
     Category: {

--- a/packages/next-admin/src/appHandler.ts
+++ b/packages/next-admin/src/appHandler.ts
@@ -109,7 +109,7 @@ export const createHandler = <P extends string = "nextadmin">({
           req
         );
 
-        const response = await submitResource({
+        let response = await submitResource({
           prisma,
           resource,
           body: transformedBody ?? body,
@@ -125,7 +125,7 @@ export const createHandler = <P extends string = "nextadmin">({
           );
         }
 
-        await editOptions?.hooks?.afterDb?.(response, mode, req);
+        response = (await editOptions?.hooks?.afterDb?.(response, mode, req)) ?? response;
 
         return NextResponse.json(response, { status: id ? 200 : 201 });
       } catch (e) {

--- a/packages/next-admin/src/appHandler.ts
+++ b/packages/next-admin/src/appHandler.ts
@@ -10,6 +10,7 @@ import {
   getResourceFromParams,
   getResources,
 } from "./utils/server";
+import { HookError } from "./exceptions/HookError";
 
 export const createHandler = <P extends string = "nextadmin">({
   apiBasePath,
@@ -97,11 +98,21 @@ export const createHandler = <P extends string = "nextadmin">({
           ? formatId(resource, ctx.params[paramKey].at(-1)!)
           : undefined;
 
+      const editOptions = options?.model?.[resource]?.edit;
+
+      const mode = !!id ? "edit" : "create";
+
       try {
+        const transformedBody = await editOptions?.hooks?.beforeDb?.(
+          body,
+          mode,
+          req
+        );
+
         const response = await submitResource({
           prisma,
           resource,
-          body,
+          body: transformedBody ?? body,
           id,
           options,
           schema,
@@ -114,8 +125,14 @@ export const createHandler = <P extends string = "nextadmin">({
           );
         }
 
+        await editOptions?.hooks?.afterDb?.(response, mode, req);
+
         return NextResponse.json(response, { status: id ? 200 : 201 });
       } catch (e) {
+        if (e instanceof HookError) {
+          return NextResponse.json(e.data, { status: e.status });
+        }
+
         return NextResponse.json(
           { error: (e as Error).message },
           { status: 500 }

--- a/packages/next-admin/src/exceptions/HookError.ts
+++ b/packages/next-admin/src/exceptions/HookError.ts
@@ -1,0 +1,17 @@
+export class HookError<T extends { error: string }> extends Error {
+  public data: T;
+
+  constructor(
+    public status: number,
+    data: T
+  ) {
+    super();
+
+    if (!data.error) {
+      throw new Error(
+        "HookError requires an error property in the data object"
+      );
+    }
+    this.data = data;
+  }
+}

--- a/packages/next-admin/src/handlers/resources.ts
+++ b/packages/next-admin/src/handlers/resources.ts
@@ -8,6 +8,7 @@ import {
   ModelName,
   NextAdminOptions,
   Permission,
+  SubmitResourceResponse,
   UploadParameters,
 } from "../types";
 import { hasPermission } from "../utils/permissions";
@@ -60,14 +61,12 @@ export const submitResource = async ({
   id,
   options,
   schema,
-}: SubmitResourceParams) => {
+}: SubmitResourceParams): Promise<SubmitResourceResponse> => {
   const { __admin_redirect: redirect, ...formValues } = body;
 
   const dmmfSchema = getPrismaModelForResource(resource);
   const parsedFormData = parseFormData(formValues, dmmfSchema?.fields!);
   const resourceIdField = getModelIdProperty(resource);
-
-  let data;
 
   const fields = options?.model?.[resource]?.edit?.fields as EditFieldsOptions<
     typeof resource

--- a/packages/next-admin/src/index.ts
+++ b/packages/next-admin/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./components/MainLayout";
 export * from "./components/NextAdmin";
 export * from "./types";
+export * from "./exceptions/HookError";

--- a/packages/next-admin/src/pageHandler.ts
+++ b/packages/next-admin/src/pageHandler.ts
@@ -144,7 +144,7 @@ export const createHandler = <P extends string = "nextadmin">({
           req
         );
 
-        const response = await submitResource({
+        let response = await submitResource({
           prisma,
           resource,
           body: transformedBody ?? body,
@@ -160,7 +160,7 @@ export const createHandler = <P extends string = "nextadmin">({
           });
         }
 
-        await editOptions?.hooks?.afterDb?.(response, mode, req);
+        response = (await editOptions?.hooks?.afterDb?.(response, mode, req)) ?? response;
 
         return res.status(id ? 200 : 201).json(response);
       } catch (e) {

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -418,7 +418,7 @@ export type EditModelHooks = {
     data: SubmitResourceResponse,
     mode: "create" | "edit",
     request: NextRequest | NextApiRequest
-  ) => Promise<void>;
+  ) => Promise<SubmitResourceResponse>;
 };
 
 export type EditOptions<T extends ModelName> = {

--- a/turbo.json
+++ b/turbo.json
@@ -37,5 +37,6 @@
     "reset-database": {
       "cache": false
     }
-  }
+  },
+  "ui": "stream"
 }


### PR DESCRIPTION
## Title

Add new `hooks` field on a model's `edit` property

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#386 

## Description

The current way to intercept data creation / edition is quite trivial and can result in complex code in the `POST` handler. This PR allows adding 2 new hooks under the `edit` property of a model :

- `beforeDb` which is executed before inserting / updating the data in the database. This allows adding or modifying some data in the values that are about to be inserted. It receives 3 parameters:
   - `data` -> the form values that are about to be inserted
   - `mode` -> either `create` or `edit`
   - `request` -> the origin request. [NextRequest](https://nextjs.org/docs/app/api-reference/functions/next-request) for App Router, [NextApiRequest](https://nextjs.org/docs/pages/building-your-application/routing/api-routes#parameters) for Page Router
- `afterDb` which is executed after an insertion / update. It is executed whether the database execution has been successful or not. It receives 3 parameters:
   - `data` -> the response of the database insertion execution. See [SubmitResourceResponse](https://github.com/premieroctet/next-admin/blob/1768e0ffb8aac56f8e6c5cc47e7ea85cc19ee62a/packages/next-admin/src/types.ts#L345)
   - `mode` -> either `create` or `edit`
   - `request` -> the origin request. [NextRequest](https://nextjs.org/docs/app/api-reference/functions/next-request) for App Router, [NextApiRequest](https://nextjs.org/docs/pages/building-your-application/routing/api-routes#parameters) for Page Router
