### PR TITLE
feat: add support to array of enums

### DIFF
--- a/.changeset/curly-penguins-explode.md
+++ b/.changeset/curly-penguins-explode.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+add support to arrays of enums

--- a/packages/next-admin/src/components/inputs/ArrayField.tsx
+++ b/packages/next-admin/src/components/inputs/ArrayField.tsx
@@ -1,7 +1,7 @@
 import { FieldProps } from "@rjsf/utils";
 import MultiSelectWidget from "./MultiSelect/MultiSelectWidget";
 import ScalarArrayField from "./ScalarArray/ScalarArrayField";
-import type { FormProps } from "../../types";
+import type { Enumeration, FormProps } from "../../types";
 
 const ArrayField = (props: FieldProps) => {
   const { formData, onChange, name, disabled, schema, required, formContext } =
@@ -23,6 +23,9 @@ const ArrayField = (props: FieldProps) => {
     );
   }
 
+  const options =
+    dmmfField?.kind === "enum" ? (schema.enum as Enumeration[]) : undefined;
+
   return (
     <MultiSelectWidget
       onChange={onChange}
@@ -31,6 +34,7 @@ const ArrayField = (props: FieldProps) => {
       disabled={disabled ?? false}
       required={required}
       schema={schema}
+      options={options}
     />
   );
 };

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayListItem.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayListItem.tsx
@@ -22,6 +22,9 @@ const MultiSelectDisplayListItem = ({
   const { basePath } = useConfig();
   const { value, label } = item;
 
+  // @ts-expect-error
+  const relationModel = item?.data?.modelName ?? schema.items?.relation;
+
   return (
     <DndItem
       sortable={sortable}
@@ -29,11 +32,11 @@ const MultiSelectDisplayListItem = ({
       value={item.value}
       label={label}
       onRemoveClick={() => onRemoveClick(value)}
-      href={`${basePath}/${slugify(
-        item?.data?.modelName ??
-          // @ts-expect-error
-          schema.items?.relation
-      )}/${value}`}
+      href={
+        relationModel
+          ? `${basePath}/${slugify(relationModel)}/${value}`
+          : undefined
+      }
     />
   );
 };

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectItem.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectItem.tsx
@@ -20,17 +20,18 @@ const MultiSelectItem = ({
 }: Props) => {
   const { basePath } = useConfig();
 
+  // @ts-expect-error
+  const relationModel = item?.data?.modelName ?? schema.items?.relation;
+
   return (
     <div className="py border-nextadmin-border-default dark:border-dark-nextadmin-border-strong text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted dark:hover:bg-dark-nextadmin-background-muted/50 hover:bg-nextadmin-background-muted relative z-10 flex cursor-default items-center justify-center rounded-md border px-2 text-sm">
-      <Link
-        href={`${basePath}/${slugify(
-          item?.data?.modelName ??
-            // @ts-expect-error
-            schema.items?.relation
-        )}/${item.value}`}
-      >
-        {item.label}
-      </Link>
+      {relationModel ? (
+        <Link href={`${basePath}/${slugify(relationModel)}/${item.value}`}>
+          {item.label}
+        </Link>
+      ) : (
+        item.label
+      )}
       {deletable && (
         <button
           type="button"

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectWidget.tsx
@@ -40,18 +40,14 @@ const MultiSelectWidget = (props: Props) => {
 
   const selectedValues = formData?.map((item: any) => item?.value) ?? [];
 
-  const optionsLeft = options?.filter(
-    (option) =>
-      !formData?.find((item: Enumeration) => item.value === option.value)
-  );
-
   const displayMode =
     !!fieldOptions && "display" in fieldOptions
       ? fieldOptions.display ?? "select"
       : "select";
 
-  // @ts-expect-error
-  const fieldSortable = displayMode === "list" && !!fieldOptions?.orderField;
+  const fieldSortable =
+    // @ts-expect-error
+    displayMode === "list" && (!!fieldOptions?.orderField || !!schema.enum);
 
   const select = (
     <select
@@ -159,7 +155,7 @@ const MultiSelectWidget = (props: Props) => {
         ref={containerRef}
         open={isOpen}
         name={name}
-        options={optionsLeft?.length ? optionsLeft : undefined}
+        options={options?.length ? options : undefined}
         onChange={(option: Enumeration) => {
           setFieldDirty(name);
           onChange([...(formData || []), option]);

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -10,6 +10,11 @@ declare type JSONSchema7Definition = JSONSchema7 & {
 };
 
 type OmitNever<T> = { [K in keyof T as T[K] extends never ? never : K]: T[K] };
+type ExtendsStringButIsNotString<T> = T extends string
+  ? string extends T
+    ? false
+    : true
+  : false;
 
 /** Type for Model */
 
@@ -220,7 +225,13 @@ export type EditFieldsOptions<T extends ModelName> = {
             }
           | { display?: "list"; orderField?: keyof ModelFromProperty<T, P> }
         )
-    : {});
+    : P extends keyof ScalarField<T>
+      ? ScalarField<T>[P] extends (infer Q)[]
+        ? ExtendsStringButIsNotString<Q> extends true
+          ? { display?: "list" | "select" }
+          : {}
+        : {}
+      : {});
 };
 
 export type Handler<
@@ -429,7 +440,7 @@ export type SidebarGroup = {
   /**
    * Some optional css classes to improve appearance of group title.
    */
-    className?: string;
+  className?: string;
   /**
    * the name of the group.
    */
@@ -834,7 +845,6 @@ export type CreateAppHandlerParams<P extends string = "nextadmin"> = {
    */
   schema: any;
 };
-
 
 export type FormProps = {
   data: any;

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -276,7 +276,14 @@ export const transformData = <M extends ModelName>(
     if (get) {
       acc[key] = get(data[key]);
     } else if (fieldKind === "enum") {
-      acc[key] = data[key] ? { label: data[key], value: data[key] } : null;
+      const value = data[key];
+      if (Array.isArray(value)) {
+        acc[key] = value.map((item) => {
+          return { label: item, value: item };
+        });
+      } else {
+        acc[key] = value ? { label: value, value } : null;
+      }
     } else if (fieldKind === "object") {
       const modelRelation = field!.type as ModelName;
       const modelRelationIdField = getModelIdProperty(modelRelation);
@@ -301,6 +308,7 @@ export const transformData = <M extends ModelName>(
           : modelRelation,
         options
       );
+
       if (Array.isArray(data[key])) {
         acc[key] = data[key].map((item: any) => {
           if (
@@ -409,7 +417,7 @@ export const findRelationInData = (
       }
     }
 
-    if (dmmfPropertyKind === "scalar" && dmmfProperty.isList) {
+    if (["scalar", "enum"].includes(dmmfPropertyKind) && dmmfProperty.isList) {
       data.forEach((item) => {
         if (item[dmmfPropertyName]) {
           item[dmmfPropertyName] = {
@@ -742,6 +750,7 @@ export const formattedFormData = async <M extends ModelName>(
           }
         } else if (dmmfPropertyKind === "scalar" && dmmfProperty.isList) {
           const dmmfPropertyName = dmmfProperty.name as keyof ScalarField<M>;
+
           const formDataValue = JSON.parse(formData[dmmfPropertyName]!) as
             | string[]
             | number[];
@@ -763,6 +772,13 @@ export const formattedFormData = async <M extends ModelName>(
               set: formDataValue,
             };
           }
+        } else if (dmmfPropertyKind === "enum" && dmmfProperty.isList) {
+          const dmmfPropertyName = dmmfProperty.name as keyof ScalarField<M>;
+
+          const data = JSON.parse(formData[dmmfPropertyName] ?? "[]");
+          formattedData[dmmfPropertyName] = {
+            set: data,
+          };
         } else {
           const dmmfPropertyName = dmmfProperty.name as keyof ScalarField<M>;
           if (formData[dmmfPropertyName] === "") {


### PR DESCRIPTION
## Title

Add support for arrays of enums.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue
#322 

## Description

- Based on #389, added support for arrays of enums reusing the `MultiSelectWidget` component.
- Also added some more types to be able to define either `list` or `select` as display when the edit field selected is an array of a Enum. 

## Screenshots

### Demo using the new feature

https://github.com/user-attachments/assets/9bf05f7c-506e-4e6a-9e62-7b9037aa9603

### Field as `select` and `list`
![select](https://github.com/user-attachments/assets/22f63965-cc2b-451a-ba08-db0a5e12d3ad)

![list](https://github.com/user-attachments/assets/e01651b6-09c7-41ca-af20-7aeefe813353)

### VSCode autocomplete example
<img width="670" alt="autocomplete" src="https://github.com/user-attachments/assets/95bacd91-219e-45c1-8b77-030cb8dc7b2e">
