### PR TITLE
feat: add search by relation

### DIFF
--- a/.changeset/hungry-poets-lie.md
+++ b/.changeset/hungry-poets-lie.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+feat: add search by relation (#385)

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -151,7 +151,8 @@ This property determines how your data is displayed in the [list View](/docs/glo
     {
       name: "search",
       type: "Array",
-      description: "an array of searchable fields",
+      description:
+        "an array of searchable fields. You can search on nested fields by concatenating them with a dot, for example author.name",
       defaultValue: "All scalar fields are searchable by default",
     },
     {

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -163,7 +163,7 @@ export const options: NextAdminOptions = {
           "rate",
           "tags",
         ],
-        search: ["title", "content", "tags"],
+        search: ["title", "content", "tags", "author.name"],
         fields: {
           author: {
             formatter: (author) => {

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -129,7 +129,7 @@ type Leaves<T> = T extends object
     }[keyof T]
   : never;
 
-export type NestableField<P extends Payload, S extends number = 8> = {
+export type NestableField<P extends Payload, S extends number = 4> = {
   [K in keyof P["scalars"]]: true;
 } & {
   [K in keyof P["objects"]]: P["objects"][K] extends infer T | null

--- a/packages/next-admin/src/utils/prisma.test.ts
+++ b/packages/next-admin/src/utils/prisma.test.ts
@@ -1,0 +1,62 @@
+import { NextAdminOptions } from "../types";
+import { createWherePredicate } from "./prisma";
+
+const options: NextAdminOptions = {
+  model: {
+    Post: {
+      list: {
+        // @ts-expect-error
+        search: ["title", "author.name", "author.email", "author.posts.title"],
+      },
+    },
+  },
+};
+
+describe("Prisma utils", () => {
+  test("createWherePredicate", () => {
+    expect(
+      createWherePredicate({
+        resource: "Post",
+        options,
+        search: "test",
+      })
+    ).toEqual({
+      AND: [
+        {
+          OR: [
+            { title: { contains: "test" } },
+            {
+              author: {
+                OR: [
+                  {
+                    name: {
+                      contains: "test",
+                    },
+                  },
+                  {
+                    email: {
+                      contains: "test",
+                    },
+                  },
+                  {
+                    posts: {
+                      some: {
+                        OR: [
+                          {
+                            title: {
+                              contains: "test",
+                            },
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+});

--- a/packages/next-admin/src/utils/prisma.test.ts
+++ b/packages/next-admin/src/utils/prisma.test.ts
@@ -5,7 +5,6 @@ const options: NextAdminOptions = {
   model: {
     Post: {
       list: {
-        // @ts-expect-error
         search: ["title", "author.name", "author.email", "author.posts.title"],
       },
     },

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -132,10 +132,12 @@ export const createWherePredicate = <M extends ModelName>({
                 field,
                 options,
                 search,
-                searchOptions: options?.model?.[resource]?.list?.search?.filter(
+                searchOptions: (
+                  options?.model?.[resource]?.list?.search as string[]
+                )?.filter(
                   (searchOption) =>
-                    searchOption.toString().startsWith(field.name)
-                ),
+                    searchOption?.toString().startsWith(field.name)
+                ) as Field<M>[],
               });
             }
 
@@ -203,10 +205,10 @@ const getFieldsFiltered = <M extends ModelName>(
     fieldsFiltered = list?.search
       ? model?.fields.filter(
           ({ name }) =>
-            list.search?.some((search) => {
-              const [searchName] = search.toString().split(".");
+            (list.search as string[])?.some((search) => {
+              const searchNameSplit = search?.toString().split(".");
 
-              return searchName === name;
+              return searchNameSplit?.[0] === name;
             })
         )
       : fieldsFiltered;


### PR DESCRIPTION
## Title

Add the ability to search in the list in relations

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#385 

## Description

Currently the search on the list page can only be done on scalar fields. This PR adds the ability to trigger the search on nested relations.

Example:

```ts
const options: NextAdminOptions = {
  model: {
    Post: {
      list: {
        search: ["title", "author.name", "author.email", "author.posts.title"],
      },
    },
  },
};
```

In the typing, the depth of nesting has been set to 4, but in theory if you ignore typing, it will go as deep as needed

## Test

A search on `author.name` has been applied on the Post model, so a simple test could be to run some search into the Post model.
