### PR TITLE
fix: fix one-to-one display for one side

### DIFF
--- a/.changeset/chilled-eggs-brush.md
+++ b/.changeset/chilled-eggs-brush.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+fix: fix one-to-one display for one side (#393)

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -20,7 +20,15 @@ export const options: NextAdminOptions = {
           format: "CSV",
           url: "/api/users/export",
         },
-        display: ["id", "name", "email", "posts", "role", "birthDate"],
+        display: [
+          "id",
+          "name",
+          "email",
+          "posts",
+          "role",
+          "birthDate",
+          "profile",
+        ],
         search: ["name", "email", "role"],
         copy: ["email"],
         filters: [
@@ -203,6 +211,16 @@ export const options: NextAdminOptions = {
         },
       },
     },
+    Profile: {
+      title: "Profiles",
+      icon: "UserIcon",
+      list: {
+        display: ["id", "user"],
+      },
+      edit: {
+        display: ["user", "bio"],
+      },
+    },
   },
   pages: {
     "/custom": {
@@ -214,7 +232,7 @@ export const options: NextAdminOptions = {
     groups: [
       {
         title: "Users",
-        models: ["User"],
+        models: ["User", "Profile"],
       },
       {
         title: "Categories",

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -375,9 +375,15 @@ export const findRelationInData = (
     const dmmfPropertyRelationToFields = dmmfProperty.relationToFields;
 
     if (dmmfPropertyKind === "object") {
+      /**
+       * Handle one-to-one relation
+       * Make sure that we are in a relation that is not a list
+       * because one side of a one-to-one relation will not have relationFromFields
+       */
       if (
-        dmmfPropertyRelationFromFields!.length > 0 &&
-        dmmfPropertyRelationToFields!.length > 0
+        (dmmfPropertyRelationFromFields!.length > 0 &&
+          dmmfPropertyRelationToFields!.length > 0) ||
+        !dmmfProperty.isList
       ) {
         const idProperty = getModelIdProperty(dmmfProperty.type as ModelName);
         data.forEach((item) => {


### PR DESCRIPTION
## Title

Fix one-to-one relationship display in list

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#393 

## Description

On our formatting for row cells, we are checking for the relationship type depending on what the DMMF says. It seems that for one-to-one relations, the DMMF indicates a relation on one side but not the other. So on the side which does not give the info, we add an extra check on the `isList` property.
