### PR TITLE
feat: allow controlling the visibility of an edit field

### DIFF
--- a/.changeset/brave-shirts-cross.md
+++ b/.changeset/brave-shirts-cross.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+eat: allow controlling the visibility of an edit field (#372)

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -2,6 +2,7 @@ import { Callout, Tabs } from "nextra/components";
 import OptionsTable from "../../../components/OptionsTable";
 
 # Model configuration
+
 <Callout type="info">
   This is the documentation for the latest version of Next Admin. If you are using an older version (`<5.0.0`), please refer to the [documentation](/v4/docs)
 </Callout>
@@ -11,7 +12,6 @@ To configure your models, you can use the `model` property of the [NextAdmin opt
 This property allows you to configure everything about how your models, their fields, their relations are displayed and edited.
 
 Example for a schema with a `User`, `Post` and `Category` model:
-
 
 ```tsx copy
 import { NextAdminOptions } from "@premieroctet/next-admin";
@@ -66,7 +66,6 @@ export const options: NextAdminOptions = {
     },
   },
 };
-
 ```
 
 It takes as **key** a model name of your schema as **value** an object to configure it.
@@ -74,67 +73,102 @@ It takes as **key** a model name of your schema as **value** an object to config
 By default, if no models are defined, they will all be displayed in the admin. If you want more control, you have to define each model individually as empty objects or with the following properties:
 
 <OptionsTable
-      options={[
-        {
-          name: "toString",
-          description: "a function that is used to display your record in related list",
-          defaultValue: "id field",
-        },
-        {
-          name: "aliases",
-          description: "an object containing the aliases of the model fields as keys, and the field name"
-        },
-        {
-          name: "title",
-          description: "a string used to display the model name in the sidebar and in the section title",
-          defaultValue: "Model name",
-        },
-        {
-          name: "list",
-          description: <>an object containing the list options (see <a href="#list-property">list property</a>)</>
-        },
-        {
-          name: "edit",
-          description: <>an object containing the edit options (see <a href="#edit-property">edit property</a>)</>
-        },
-        {
-          name: "actions",
-          description: <> an array of actions (see <a href="#actions-property">actions property</a>)</>
-        },
-        {
-          name: "icon",
-          description: <>the outline <a href="https://heroicons.com/" target="_blank">HeroIcon</a> name displayed in the sidebar and pages title</>,
-        },
-        {
-          name: "permissions",
-          description: "an array to specify restricted permissions on model",
-          defaultValue: "[`create`, `edit`, `delete`]"
-        },
-  ]} />
+  options={[
+    {
+      name: "toString",
+      description:
+        "a function that is used to display your record in related list",
+      defaultValue: "id field",
+    },
+    {
+      name: "aliases",
+      description:
+        "an object containing the aliases of the model fields as keys, and the field name",
+    },
+    {
+      name: "title",
+      description:
+        "a string used to display the model name in the sidebar and in the section title",
+      defaultValue: "Model name",
+    },
+    {
+      name: "list",
+      description: (
+        <>
+          an object containing the list options (see{" "}
+          <a href="#list-property">list property</a>)
+        </>
+      ),
+    },
+    {
+      name: "edit",
+      description: (
+        <>
+          an object containing the edit options (see{" "}
+          <a href="#edit-property">edit property</a>)
+        </>
+      ),
+    },
+    {
+      name: "actions",
+      description: (
+        <>
+          {" "}
+          an array of actions (see <a href="#actions-property">
+            actions property
+          </a>)
+        </>
+      ),
+    },
+    {
+      name: "icon",
+      description: (
+        <>
+          the outline{" "}
+          <a href="https://heroicons.com/" target="_blank">
+            HeroIcon
+          </a>{" "}
+          name displayed in the sidebar and pages title
+        </>
+      ),
+    },
+    {
+      name: "permissions",
+      description: "an array to specify restricted permissions on model",
+      defaultValue: "[`create`, `edit`, `delete`]",
+    },
+  ]}
+/>
 
 You can customize the following for each model:
 
 ## `list` property
 
 This property determines how your data is displayed in the [list View](/docs/glossary#list-view)
-<OptionsTable 
+
+<OptionsTable
   options={[
     {
       name: "search",
       type: "Array",
       description: "an array of searchable fields",
-      defaultValue: 'All scalar fields are searchable by default',
+      defaultValue: "All scalar fields are searchable by default",
     },
     {
       name: "display",
       type: "Array",
       description: "an array of fields that are displayed in the list",
-      defaultValue: 'All scalar fields are displayed by default',
+      defaultValue: "All scalar fields are displayed by default",
     },
     {
       name: "fields",
       type: "Object",
-      description: <>an object containing the model fields as keys, and customization values (see <a href="#listfields-property">fields property</a>)</>,
+      description: (
+        <>
+          an object containing the model fields as keys, and customization
+          values (see <a href="#listfields-property">fields property</a>)
+        </>
+      ),
     },
     {
       name: "copy",
@@ -145,12 +179,14 @@ This property determines how your data is displayed in the [list View](/docs/glo
     {
       name: "defaultSort",
       type: "Object",
-      description: "an optional object to determine the default sort to apply on the list",
+      description:
+        "an optional object to determine the default sort to apply on the list",
     },
     {
       name: "defaultSort.field",
       type: "String",
-      description: "the model's field name to which the sort is applied. It is mandatory",
+      description:
+        "the model's field name to which the sort is applied. It is mandatory",
     },
     {
       name: "defaultSort.direction",
@@ -160,34 +196,55 @@ This property determines how your data is displayed in the [list View](/docs/glo
     {
       name: "filters",
       type: "Array",
-      description: <> define a set of Prisma filters that user can choose in list (see <a href="#listfilters-property">filters</a>)</>,
+      description: (
+        <>
+          {" "}
+          define a set of Prisma filters that user can choose in list (see <a href="#listfilters-property">
+            filters
+          </a>)
+        </>
+      ),
     },
     {
       name: "exports",
       type: "Object",
-      description: <>an object or array of export - containing export url (see <a href="#listexports-property">exports</a>)</>,
+      description: (
+        <>
+          an object or array of export - containing export url (see{" "}
+          <a href="#listexports-property">exports</a>)
+        </>
+      ),
     },
   ]}
 />
 <Callout type="info">
-  The `search` property is only available for [`scalar` fields](https://www.prisma.io/docs/orm/reference/prisma-schema-reference#model-field-scalar-types).
+  The `search` property is only available for [`scalar`
+  fields](https://www.prisma.io/docs/orm/reference/prisma-schema-reference#model-field-scalar-types).
 </Callout>
 
 #### `list.fields` property
+
 The `fields` property is an object that can have the following properties:
 
 <OptionsTable
   options={[
-        {
-          name: "formatter",
-          type: "Function",
-          description: <>a function that takes the field value as a parameter, and returns a JSX node. It also accepts a second argument which is the <a href="#nextadmin-context">NextAdmin context</a></>,
-        },
-        {
-          name: "sortBy",
-          type: "String",
-          description: "available only on many-to-one models. The name of a field in the related model to apply the sort to. Defaults to the id field of the related model",
-        },
+    {
+      name: "formatter",
+      type: "Function",
+      description: (
+        <>
+          a function that takes the field value as a parameter, and returns a
+          JSX node. It also accepts a second argument which is the{" "}
+          <a href="#nextadmin-context">NextAdmin context</a>
+        </>
+      ),
+    },
+    {
+      name: "sortBy",
+      type: "String",
+      description:
+        "available only on many-to-one models. The name of a field in the related model to apply the sort to. Defaults to the id field of the related model",
+    },
   ]}
 />
 
@@ -211,7 +268,15 @@ The `filters` property allow you to define a set of Prisma filters that user can
     {
       name: "value",
       type: "String",
-      description: <>a where clause Prisma filter of the related model (e.g. <a href="https://www.prisma.io/docs/orm/reference/prisma-client-reference#filter-conditions-and-operators">Prisma operators</a>)</>,
+      description: (
+        <>
+          a where clause Prisma filter of the related model (e.g.{" "}
+          <a href="https://www.prisma.io/docs/orm/reference/prisma-client-reference#filter-conditions-and-operators">
+            Prisma operators
+          </a>
+          )
+        </>
+      ),
     },
   ]}
 />
@@ -225,7 +290,8 @@ The `exports` property is available in the `list` property. It's an object or an
     {
       name: "format",
       type: "String",
-      description: "a string defining the format of the export. It's used to label the export button",
+      description:
+        "a string defining the format of the export. It's used to label the export button",
       defaultValue: "undefined",
     },
     {
@@ -238,49 +304,73 @@ The `exports` property is available in the `list` property. It's an object or an
 />
 
 <Callout type="info">
-  The `exports` property does not account for active filters. If you want to export filtered data, you need to add the filters to the URL or in your export action.
+  The `exports` property does not account for active filters. If you want to
+  export filtered data, you need to add the filters to the URL or in your export
+  action.
 </Callout>
-
-
 
 ## `edit` property
 
 This property determines how your data is displayed in the [edit view](/docs/glossary#edit-view)
-  <OptionsTable
-        options={[
+
+{" "}
+<OptionsTable
+  options={[
     {
       name: "display",
       type: "Array",
-            description: <> an array of fields that are displayed in the form. It can also be an object that will be displayed in the form of a notice (see <a href="#notice">notice</a>)</>,
+      description: (
+        <>
+          {" "}
+          an array of fields that are displayed in the form. It can also be an object
+          that will be displayed in the form of a notice (see <a href="#notice">
+            notice
+          </a>)
+        </>
+      ),
       defaultValue: "all scalar fields are displayed",
     },
     {
       name: "styles",
       type: "Object",
-      description: <>an object containing the styles of the form (see <a href="#editstyles-property">styles</a>) </>,
+      description: (
+        <>
+          an object containing the styles of the form (see{" "}
+          <a href="#editstyles-property">styles</a>){" "}
+        </>
+      ),
     },
     {
       name: "fields",
       type: "Object",
-      description: <>an object containing the model fields as keys, and customization values (see <a href="#editfields-property">fields property</a>)</>,
+      description: (
+        <>
+          an object containing the model fields as keys, and customization
+          values (see <a href="#editfields-property">fields property</a>)
+        </>
+      ),
     },
     {
       name: "submissionErrorMessage",
       type: "String",
-      description: "a message displayed if an error occurs during the form submission",
+      description:
+        "a message displayed if an error occurs during the form submission",
       defaultValue: "'Submission error'",
     },
   ]}
-  />
+/>
 
 #### `edit.styles` property
 
 The `styles` property is available in the `edit` property.
+
 <Callout emoji="⚠️">
-  If your options are defined in a separate file, make sure to add the path to the `content` property of the `tailwind.config.js` file (see [TailwindCSS configuration](/docs/getting-started#tailwindcss-configuration)).
+  If your options are defined in a separate file, make sure to add the path to
+  the `content` property of the `tailwind.config.js` file (see [TailwindCSS
+  configuration](/docs/getting-started#tailwindcss-configuration)).
 </Callout>
 
-<OptionsTable 
+<OptionsTable
   options={[
     {
       name: "_form",
@@ -290,7 +380,8 @@ The `styles` property is available in the `edit` property.
     {
       name: "...",
       type: "String",
-      description: "all fields of the model, wwith the field name as the key and the classname as the value",
+      description:
+        "all fields of the model, wwith the field name as the key and the classname as the value",
     },
   ]}
 />
@@ -304,98 +395,160 @@ styles: {
 };
 ```
 
-#### `edit.fields` property 
+#### `edit.fields` property
 
 This property can be defined for each field of the corresponding model.
 When you define a field, use the field's name as the key and the following object as the value:
 
 <OptionsTable
-      options={[
-        {
-          name: "validate",
-          type: "Function",
-          description: "a function that takes the field value as a parameter, and returns a boolean",
-        },
-        {
-          name: "format",
-          type: "String",
-          description: <>a string defining an OpenAPI field format, overriding the one set in the generator. An extra <code>file</code> format can be used to be able to have a file input</>,
-        },
-        {
-          name: "input",
-          type: "React Element",
-          description: <>a React Element that should receive <a href="#custominputprops">CustomInputProps</a>. For App Router, this element must be a client component</>,
-        },
-        {
-          name: "handler",
-          type: "Object",
-          description: "",
-        },
-        {
-          name: "handler.get",
-          type: "Function",
-          description: "a function that takes the field value as a parameter and returns a transformed value displayed in the form",
-        },
-        {
-          name: "handler.upload",
-          type: "Function",
-          description: <>an async function that is used only for formats <code>file</code> and <code>data-url</code>. It takes a Buffer object and an information object containing <code>name</code> and <code>type</code> properties as parameters and must return a string. It can be useful to upload a file to a remote provider</>,
-        },
-        {
-          name: "handler.uploadErrorMessage",
-          type: "String",
-          description: "an optional string displayed in the input field as an error message in case of a failure during the upload handler",
-        },
-        {
-          name: "optionFormatter",
-          type: "Function",
-          description: "only for relation fields, a function that takes the field values as a parameter and returns a string. Useful to display your record in related list",
-        },
-        {
-          name: "tooltip",
-          type: "String",
-          description: "A tooltip content to display for the field ",
-        },
-        {
-          name: "helperText",
-          type: "String",
-          description: "a helper text that is displayed underneath the input",
-        },
-        {
-          name: "disabled",
-          type: "Boolean",
-          description: "a boolean to indicate that the field is read only",
-        },
-        {
-          name: "display",
-          type: "String",
-          description: <> only for relation fields, indicate which display format to use between <code>list</code>, <code>table</code> or <code>select</code></>, 
-          defaultValue: "select",
-        },
-        {
-          name: "required",
-          type: "Boolean",
-          description: <>a true value to force a field to be required in the form, note that if the field is required by the Prisma schema, you cannot set <code>required</code> to false</>,
-        },
-        {
-          name: "relationOptionFormatter",
-          type: "Function",
-          description: <>same as <code>optionFormatter</code>, but used to format data that comes from an <a href="https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/many-to-many-relations#explicit-many-to-many-relations">explicit many-to-many</a> relationship</>,
-            },
-        {
-          name: "orderField",
-          type: "String",
-          description: <>the field to use for relationship sorting. This allows to drag and drop the related records in the <code>list</code> display</>,
-        },
-        {
-          name: "relationshipSearchField",
-          type: "String",
-          description: <>a field name of the explicit many-to-many relation table to apply the search on. See <a href="https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/many-to-many-relations#explicit-many-to-many-relations">handling explicit many-to-many</a></>,
-            },
-      ]}
-    />
-
-
+  options={[
+    {
+      name: "validate",
+      type: "Function",
+      description:
+        "a function that takes the field value as a parameter, and returns a boolean",
+    },
+    {
+      name: "format",
+      type: "String",
+      description: (
+        <>
+          a string defining an OpenAPI field format, overriding the one set in
+          the generator. An extra <code>file</code> format can be used to be
+          able to have a file input
+        </>
+      ),
+    },
+    {
+      name: "input",
+      type: "React Element",
+      description: (
+        <>
+          a React Element that should receive{" "}
+          <a href="#custominputprops">CustomInputProps</a>. For App Router, this
+          element must be a client component
+        </>
+      ),
+    },
+    {
+      name: "handler",
+      type: "Object",
+      description: "",
+    },
+    {
+      name: "handler.get",
+      type: "Function",
+      description:
+        "a function that takes the field value as a parameter and returns a transformed value displayed in the form",
+    },
+    {
+      name: "handler.upload",
+      type: "Function",
+      description: (
+        <>
+          an async function that is used only for formats <code>file</code> and{" "}
+          <code>data-url</code>. It takes a Buffer object and an information
+          object containing <code>name</code> and <code>type</code> properties
+          as parameters and must return a string. It can be useful to upload a
+          file to a remote provider
+        </>
+      ),
+    },
+    {
+      name: "handler.uploadErrorMessage",
+      type: "String",
+      description:
+        "an optional string displayed in the input field as an error message in case of a failure during the upload handler",
+    },
+    {
+      name: "optionFormatter",
+      type: "Function",
+      description:
+        "only for relation fields, a function that takes the field values as a parameter and returns a string. Useful to display your record in related list",
+    },
+    {
+      name: "tooltip",
+      type: "String",
+      description: "A tooltip content to display for the field ",
+    },
+    {
+      name: "helperText",
+      type: "String",
+      description: "a helper text that is displayed underneath the input",
+    },
+    {
+      name: "disabled",
+      type: "Boolean",
+      description: "a boolean to indicate that the field is read only",
+    },
+    {
+      name: "display",
+      type: "String",
+      description: (
+        <>
+          {" "}
+          only for relation fields, indicate which display format to use between{" "}
+          <code>list</code>, <code>table</code> or <code>select</code>
+        </>
+      ),
+      defaultValue: "select",
+    },
+    {
+      name: "required",
+      type: "Boolean",
+      description: (
+        <>
+          a true value to force a field to be required in the form, note that if
+          the field is required by the Prisma schema, you cannot set{" "}
+          <code>required</code> to false
+        </>
+      ),
+    },
+    {
+      name: "relationOptionFormatter",
+      type: "Function",
+      description: (
+        <>
+          same as <code>optionFormatter</code>, but used to format data that
+          comes from an{" "}
+          <a href="https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/many-to-many-relations#explicit-many-to-many-relations">
+            explicit many-to-many
+          </a>{" "}
+          relationship
+        </>
+      ),
+    },
+    {
+      name: "orderField",
+      type: "String",
+      description: (
+        <>
+          the field to use for relationship sorting. This allows to drag and
+          drop the related records in the <code>list</code> display
+        </>
+      ),
+    },
+    {
+      name: "relationshipSearchField",
+      type: "String",
+      description: (
+        <>
+          a field name of the explicit many-to-many relation table to apply the
+          search on. See{" "}
+          <a href="https://www.prisma.io/docs/orm/prisma-schema/data-model/relations/many-to-many-relations#explicit-many-to-many-relations">
+            handling explicit many-to-many
+          </a>
+        </>
+      ),
+    },
+    {
+      name: "visible",
+      type: "Function",
+      description:
+        "a function that takes the resource value as a parameter, and returns a boolean that shows or hides the field in the edit form",
+    },
+  ]}
+/>
 
 ## `actions` property
 
@@ -407,7 +560,7 @@ The `actions` property is an array of objects that allows you to define a set of
       name: "title",
       type: "String",
       description: "action title that will be shown in the action dropdown",
-        },
+    },
     {
       name: "id",
       type: "String",
@@ -416,12 +569,18 @@ The `actions` property is an array of objects that allows you to define a set of
     {
       name: "action",
       type: "Function",
-      description: <>an async function that will be triggered when selecting the action in the dropdown. For App Router, it must be defined as a server action</>,
+      description: (
+        <>
+          an async function that will be triggered when selecting the action in
+          the dropdown. For App Router, it must be defined as a server action
+        </>
+      ),
     },
     {
       name: "successMessage",
       type: "String",
-      description: "a message that will be displayed when the action is successful",
+      description:
+        "a message that will be displayed when the action is successful",
     },
     {
       name: "errorMessage",
@@ -431,7 +590,7 @@ The `actions` property is an array of objects that allows you to define a set of
   ]}
 />
 
-## NextAdmin Context 
+## NextAdmin Context
 
 The `NextAdmin` context is an object containing the following properties:
 
@@ -440,7 +599,15 @@ The `NextAdmin` context is an object containing the following properties:
     {
       name: "locale",
       type: "String",
-      description: <>The locale used by the calling page. (refers to the <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language">accept-language</a> header)</>,
+      description: (
+        <>
+          The locale used by the calling page. (refers to the{" "}
+          <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language">
+            accept-language
+          </a>{" "}
+          header)
+        </>
+      ),
     },
     {
       name: "row",
@@ -450,10 +617,9 @@ The `NextAdmin` context is an object containing the following properties:
   ]}
 />
 
-
 ## Notice
 
-The edit page's form can display notice alerts. To do so, you can pass objects in the `display` array of the `edit` property of a model. 
+The edit page's form can display notice alerts. To do so, you can pass objects in the `display` array of the `edit` property of a model.
 This can be useful to display alerts or information to the user when editing a record.
 This object takes the following properties :
 
@@ -467,7 +633,12 @@ This object takes the following properties :
     {
       name: "id",
       type: "String",
-      description: <>A unique identifier for the notice that can be used to style it with the <code>styles</code> property. This is mandatory</>,
+      description: (
+        <>
+          A unique identifier for the notice that can be used to style it with
+          the <code>styles</code> property. This is mandatory
+        </>
+      ),
     },
     {
       name: "description",
@@ -517,7 +688,9 @@ In this example, the `email-notice` notice will be displayed in the form before 
 ![Notice example](/docs/notice-exemple.png)
 
 ## CustomInputProps
+
 Represents the props that are passed to the custom input component.
+
 <OptionsTable
   options={[
     {
@@ -533,7 +706,14 @@ Represents the props that are passed to the custom input component.
     {
       name: "onChange",
       type: "Function",
-      description: <> a function taking a <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event">ChangeEvent</a> as a parameter</>,
+      description: (
+        <>
+          {" "}
+          a function taking a <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event">
+            ChangeEvent
+          </a> as a parameter
+        </>
+      ),
     },
     {
       name: "readonly",

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -204,6 +204,10 @@ export type EditFieldsOptions<T extends ModelName> = {
      * a true value to force a field to be required in the form, note that if the field is required by the Prisma schema, you cannot set `required` to false
      */
     required?: true;
+    /**
+     * a function that takes the field value as parameter and returns a boolean to determine if the field is displayed in the form.
+     */
+    visible?: (value: ModelWithoutRelationships<T>) => boolean;
   } & (P extends keyof ObjectField<T>
     ? OptionFormatterFromRelationshipSearch<T, P> &
         (
@@ -429,7 +433,7 @@ export type SidebarGroup = {
   /**
    * Some optional css classes to improve appearance of group title.
    */
-    className?: string;
+  className?: string;
   /**
    * the name of the group.
    */
@@ -834,7 +838,6 @@ export type CreateAppHandlerParams<P extends string = "nextadmin"> = {
    */
   schema: any;
 };
-
 
 export type FormProps = {
   data: any;

--- a/packages/next-admin/src/utils/props.ts
+++ b/packages/next-admin/src/utils/props.ts
@@ -13,6 +13,7 @@ import {
 import { getCustomInputs } from "./options";
 import { getDataItem, getMappedDataList } from "./prisma";
 import {
+  applyVisiblePropertiesInSchema,
   getModelIdProperty,
   getPrismaModelForResource,
   getResourceFromParams,
@@ -176,6 +177,8 @@ export async function getPropsFromParams({
           ? toStringFunction(data)
           : resourceId.toString();
 
+        applyVisiblePropertiesInSchema(resource, edit, data, deepCopySchema);
+
         return {
           ...defaultProps,
           resource,
@@ -210,7 +213,6 @@ export const getMainLayoutProps = ({
   options,
   params,
   isAppDir = true,
-  
 }: GetMainLayoutPropsParams): MainLayoutProps => {
   if (params !== undefined && !Array.isArray(params)) {
     throw new Error(

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -854,6 +854,31 @@ export const transformSchema = <M extends ModelName>(
     orderSchema(resource, options)
   );
 
+export const applyVisiblePropertiesInSchema = <M extends ModelName>(
+  resource: M,
+  edit: EditOptions<M>,
+  data: any,
+  schema: Schema
+) => {
+  const modelName = resource;
+  const model = models.find((model) => model.name === modelName);
+  if (!model) return schema;
+  const display = edit?.display;
+  const fields = edit?.fields;
+  if (display) {
+    display.forEach((property) => {
+      if (
+        schema.definitions?.[modelName]?.properties &&
+        fields?.[property]?.visible?.(data) === false
+      ) {
+        // @ts-expect-error
+        delete schema.definitions[modelName].properties[property];
+      }
+    });
+  }
+  return schema;
+};
+
 const fillDescriptionInSchema = <M extends ModelName>(
   resource: M,
   editOptions: EditOptions<M>


### PR DESCRIPTION
## Title

Allow controlling the visibility of an edit field with a function

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#372 

## Description

Add a function in the edit fields options that takes the resource value as parameter and returns a boolean that will show or hide the field in the edit form.
