### PR TITLE
fix: default empty state to title before resource in lowercase

### DIFF
--- a/.changeset/eight-trainers-judge.md
+++ b/.changeset/eight-trainers-judge.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+default resource names to title before the resource in lowercase

--- a/packages/next-admin/src/components/EmptyState.tsx
+++ b/packages/next-admin/src/components/EmptyState.tsx
@@ -21,7 +21,11 @@ const EmptyState = ({
   const hasCreatePermission =
     !modelOptions?.permissions || modelOptions?.permissions?.includes("create");
 
-  const resourceName = t(`model.${resource}.name`, {}, resource.toLowerCase());
+  const resourceName = t(
+    `model.${resource}.name`,
+    {},
+    modelOptions?.title ?? resource.toLowerCase()
+  );
 
   return (
     <div className="py-10 text-center">


### PR DESCRIPTION
## Title
Default empty state to title before the resource in lowercase.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue
#400 

## Description

Right now, the empty state is using translations to show the name of the resource, and if the translation is not present, it's showing the resource name in lowercase as fallback. With this PR, instead of showing that, we show the resource title that was set in the options file (if present).  