### PR TITLE
fix: set hashed password optional

### DIFF
--- a/.changeset/chilled-baboons-warn.md
+++ b/.changeset/chilled-baboons-warn.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: set hashed password optional

--- a/apps/example/prisma/migrations/20240907035434_add_hashed_password_field/migration.sql
+++ b/apps/example/prisma/migrations/20240907035434_add_hashed_password_field/migration.sql
@@ -1,8 +1,11 @@
 /*
-  Warnings:
-
-  - Added the required column `hashedPassword` to the `User` table without a default value. This is not possible if the table is not empty.
-
-*/
+ Warnings:
+ 
+ - Added the required column `hashedPassword` to the `User` table without a default value. This is not possible if the table is not empty.
+ 
+ */
 -- AlterTable
-ALTER TABLE "User" ADD COLUMN     "hashedPassword" TEXT NOT NULL;
+ALTER TABLE
+  "User"
+ADD
+  COLUMN "hashedPassword" TEXT;

--- a/apps/example/prisma/schema.prisma
+++ b/apps/example/prisma/schema.prisma
@@ -25,7 +25,7 @@ enum Role {
 model User {
   id             Int       @id @default(autoincrement())
   email          String    @unique
-  hashedPassword String
+  hashedPassword String?
   name           String?
   posts          Post[]    @relation("author") // One-to-many relation
   profile        Profile?  @relation("profile") // One-to-one relation


### PR DESCRIPTION
## Title

Fix the User schema for hashedPassword

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement
