### PR TITLE
fix: crash when options.model.edit is not defined

### DIFF
--- a/.changeset/clever-coins-teach.md
+++ b/.changeset/clever-coins-teach.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix crash when edit object is not defined in options.model

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -1014,7 +1014,7 @@ export const removeHiddenProperties =
 export const addCustomProperties =
   <M extends ModelName>(resource: M, editOptions: EditOptions<M>) =>
   (schema: Schema) => {
-    const customFieldKeys = Object.keys(editOptions.customFields ?? {});
+    const customFieldKeys = Object.keys(editOptions?.customFields ?? {});
 
     customFieldKeys.forEach((property) => {
       const fieldOptions = editOptions?.customFields?.[property];


### PR DESCRIPTION
## Title

Fix crash when edit options are not defined

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [x] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

[Linked issues]

## Description

If model object doesn't define `edit: {}` it is crashing admin panel. It originated in https://github.com/premieroctet/next-admin/pull/406

## Testing

`yarn test` passes.

## Impact

Nothing.

## Additional Information

Nothing.
