### PR TITLE
feat: use exports field

### DIFF
--- a/.changeset/shiny-clouds-appear.md
+++ b/.changeset/shiny-clouds-appear.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": major
+---
+
+feat: use exports field (#379)

--- a/apps/docs/pages/docs/code-snippets.mdx
+++ b/apps/docs/pages/docs/code-snippets.mdx
@@ -370,7 +370,7 @@ You can create custom pages in the Next Admin UI. By reusing the `MainLayout` co
 ```typescript copy filename="app/custom/page.tsx"
 
 import { MainLayout } from "@premieroctet/next-admin";
-import { getMainLayoutProps } from "@premieroctet/next-admin/dist/appRouter";
+import { getMainLayoutProps } from "@premieroctet/next-admin/appRouter";
 import { options } from "@/options";
 import { prisma } from "@/prisma";
 

--- a/apps/docs/pages/docs/getting-started.mdx
+++ b/apps/docs/pages/docs/getting-started.mdx
@@ -40,7 +40,7 @@ module.exports = {
     "./node_modules/@premieroctet/next-admin/dist/**/*.{js,ts,jsx,tsx}",
   ],
   darkMode: "class",
-  presets: [require("@premieroctet/next-admin/dist/preset")],
+  presets: [require("@premieroctet/next-admin/preset")],
 };
 ```
 
@@ -78,7 +78,7 @@ Next-Admin uses a dynamic route `[[...nextadmin]]` to handle all the admin route
 
     ```tsx copy filename="app/admin/[[...nextadmin]]/page.tsx"
     import { NextAdmin, PageProps } from "@premieroctet/next-admin";
-    import { getNextAdminProps } from "@premieroctet/next-admin/dist/appRouter";
+    import { getNextAdminProps } from "@premieroctet/next-admin/appRouter";
     import { prisma } from "@/prisma";
     import schema from "@/prisma/json-schema/json-schema.json";
     import "@/styles.css" // .css file containing tailiwnd rules
@@ -121,7 +121,7 @@ Next-Admin uses a dynamic route `[[...nextadmin]]` to handle all the admin route
     ```tsx copy filename="pages/admin/[[...nextadmin]].ts"
     import { AdminComponentProps, NextAdmin } from "@premieroctet/next-admin";
 
-    import { getNextAdminProps } from "@premieroctet/next-admin/dist/pageRouter";
+    import { getNextAdminProps } from "@premieroctet/next-admin/pageRouter";
     import { GetServerSideProps } from "next";
     import { prisma } from " @/prisma";
     import schema from "@/prisma/json-schema/json-schema.json";
@@ -226,7 +226,7 @@ module.exports = {
 
   </Tabs.Tab>
 
-  More information about the `getNextAdminProps` [here](/docs/api/get-next-admin-props-function).
+More information about the `getNextAdminProps` [here](/docs/api/get-next-admin-props-function).
 
 </Tabs>
 
@@ -240,7 +240,7 @@ Next-Admin uses a dynamic route `[[...nextadmin]]` to handle all the API routes.
     ```ts copy filename="app/api/admin/[[...nextadmin]]/route.ts"
     import { prisma } from "@/prisma";
     import schema from "@/prisma/json-schema/json-schema.json";
-    import { createHandler } from "@premieroctet/next-admin/dist/appHandler";
+    import { createHandler } from "@premieroctet/next-admin/appHandler";
 
     const { run } = createHandler({
       apiBasePath: "/api/admin",
@@ -257,7 +257,7 @@ Next-Admin uses a dynamic route `[[...nextadmin]]` to handle all the API routes.
 
       ```ts copy filename="pages/api/admin/[[...nextadmin]].ts"
       import { prisma } from "@/prisma";
-      import { createHandler } from "@premieroctet/next-admin/dist/pageHandler";
+      import { createHandler } from "@premieroctet/next-admin/pageHandler";
       import schema from "@/prisma/json-schema/json-schema.json";
 
       export const config = {
@@ -279,9 +279,11 @@ Next-Admin uses a dynamic route `[[...nextadmin]]` to handle all the API routes.
       <Callout emoji="⚠️">
         Make sure to export the config object to define no `bodyParser`. This is required to be able to parse FormData.
       </Callout>
+
   </Tabs.Tab>
 
-  More information about the `createHandler` function [here](/docs/api/create-handler-function).
+More information about the `createHandler` function [here](/docs/api/create-handler-function).
+
 </Tabs>
 
 ### Next Admin options - optional

--- a/apps/docs/pages/docs/theming.mdx
+++ b/apps/docs/pages/docs/theming.mdx
@@ -16,7 +16,7 @@ module.exports = {
     // your own content
     "./node_modules/@premieroctet/next-admin/dist/**/*.{js,ts,jsx,tsx}",
   ],
-  presets: [require("@premieroctet/next-admin/dist/preset")],
+  presets: [require("@premieroctet/next-admin/preset")],
 };
 ```
 
@@ -52,7 +52,7 @@ module.exports = {
       }
     }
   }
-  presets: [require("@premieroctet/next-admin/dist/preset")],
+  presets: [require("@premieroctet/next-admin/preset")],
 };
 ```
 

--- a/apps/docs/pages/docs/v5-migration-guide.mdx
+++ b/apps/docs/pages/docs/v5-migration-guide.mdx
@@ -1,7 +1,8 @@
-import { Callout, Steps, Tabs } from 'nextra/components';
-import OptionsTable from '../../components/OptionsTable';
+import { Callout, Steps, Tabs } from "nextra/components";
+import OptionsTable from "../../components/OptionsTable";
 
 ## Why migrate?
+
 Next Admin v5 is a major release that comes with a lot of improvements. It is also a breaking change, so you will need to update your code to make it work with the new version.
 We decided to make this breaking change to make the library easier to use.
 Actions are removed in v5 and replaced by a catch-all API route `[[...nextadmin]]` that handles all the next-admin API routes.
@@ -11,38 +12,33 @@ Actions are removed in v5 and replaced by a catch-all API route `[[...nextadmin]
 <Steps>
   ### Upgrade the package
 
-  First, you need to upgrade the package to the latest version. You can do this by running the following command:
+First, you need to upgrade the package to the latest version. You can do this by running the following command:
 
-  <Tabs items={['yarn', 'npm', 'pnpm']}>
-    <Tabs.Tab>
-      ```bash copy
-  yarn add @premieroctet/next-admin@latest
-      ```
-    </Tabs.Tab>
-    <Tabs.Tab>
-      ```bash copy
-  npm install -S @premieroctet/next-admin@latest
-      ```
-    </Tabs.Tab>
-    <Tabs.Tab>
-      ```bash copy
-  pnpm install -S @premieroctet/next-admin@latest
-      ```
-    </Tabs.Tab>
-  </Tabs>
+{" "}
+<Tabs items={["yarn", "npm", "pnpm"]}>
+  <Tabs.Tab>```bash copy yarn add @premieroctet/next-admin@latest ```</Tabs.Tab>
+  <Tabs.Tab>
+    ```bash copy npm install -S @premieroctet/next-admin@latest ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash copy pnpm install -S @premieroctet/next-admin@latest ```
+  </Tabs.Tab>
+</Tabs>
 
-  ### Create the `[[...nextadmin]]` API route
+### Create the `[[...nextadmin]]` API route
 
-  Next Admin v5 uses a catch-all route `[[...nextadmin]]` to handle all the API routes. You need to create this route in your project.
+Next Admin v5 uses a catch-all route `[[...nextadmin]]` to handle all the API routes. You need to create this route in your project.
 
-  <Callout type='info'>
-    Refer to [this guide](/docs/route) to know where you should create the `[[...nextadmin]]` route.
-  </Callout>
+{" "}
+<Callout type="info">
+  Refer to [this guide](/docs/route) to know where you should create the
+  `[[...nextadmin]]` route.
+</Callout>
 
   <Tabs items={['App Router', 'Pages Router']}>
     <Tabs.Tab>
     ```ts copy filename="app/api/admin/[[...nextadmin]]/route.ts"
-      import { createHandler } from '@premieroctet/next-admin/dist/appHandler';
+      import { createHandler } from '@premieroctet/next-admin/appHandler';
       import schema from '@/path/to/json-schema.json';
       import prisma from '@/path/to/prisma/client';
       import { options } from '@/path/to/next-admin-options';
@@ -59,45 +55,49 @@ Actions are removed in v5 and replaced by a catch-all API route `[[...nextadmin]
     </Tabs.Tab>
     <Tabs.Tab>
     ```ts copy filename="pages/api/admin/[[...nextadmin]].ts"
-      import { createHandler } from '@premieroctet/next-admin/dist/pageHandler';
+      import { createHandler } from '@premieroctet/next-admin/pageHandler';
       import schema from '@/path/to/json-schema.json';
       import prisma from '@/path/to/prisma/client';
       import { options } from '@/path/to/next-admin-options';
-      
+
       export const config = {
         api: {
           bodyParser: false,
         },
       };
-      
+
       const { run } = createHandler({
         apiBasePath: '/api/admin',
         prisma,
         schema,
         options, // optional
       });
-      
+
       export default run;
     ```
-    
+
     </Tabs.Tab>
+
   </Tabs>
 
-  ### Remove `basePath` property
-  The `options` property is not required anymore, so we moved the `basePath` (required) to the `<NextAdmin />` component. You can remove it from your `options` object.
+### Remove `basePath` property
 
-  ### Remove server actions
-  If you were using App Router you had to create server actions to perform some operations.
-  In v5 these actions are no longer needed. You can remove them from your project.
+The `options` property is not required anymore, so we moved the `basePath` (required) to the `<NextAdmin />` component. You can remove it from your `options` object.
 
-  ### Update your Next-Admin page 
-  Update your Next-Admin page to use the **new** `getNextAdminProps` **function** (more details [here](/docs/api/get-next-admin-props-function)).
+### Remove server actions
+
+If you were using App Router you had to create server actions to perform some operations.
+In v5 these actions are no longer needed. You can remove them from your project.
+
+### Update your Next-Admin page
+
+Update your Next-Admin page to use the **new** `getNextAdminProps` **function** (more details [here](/docs/api/get-next-admin-props-function)).
 
   <Tabs items={['App Router', 'Pages Router']}>
     <Tabs.Tab>
     ```ts copy filename="app/admin/[[...nextadmin]]/page.tsx"
       import { NextAdmin, PageProps } from '@premieroctet/next-admin';
-      import { getNextAdminProps } from '@premieroctet/next-admin/dist/appRouter';
+      import { getNextAdminProps } from '@premieroctet/next-admin/appRouter';
       import prisma from '@/path/to/prisma/client';
       import schema from '@/prisma/json-schema/json-schema.json';
       import { options } from '@/path/to/next-admin-options';
@@ -124,7 +124,7 @@ Actions are removed in v5 and replaced by a catch-all API route `[[...nextadmin]
     <Tabs.Tab>
     ```ts copy filename="pages/api/admin/[[...nextadmin]].ts"
       import { AdminComponentProps, NextAdmin } from '@premieroctet/next-admin';
-      import { getNextAdminProps } from '@premieroctet/next-admin/dist/pageRouter';
+      import { getNextAdminProps } from '@premieroctet/next-admin/pageRouter';
       import { GetServerSideProps } from 'next';
       import prisma from ' @/path/to/prisma/client';
       import schema from '@/prisma/json-schema/json-schema.json';
@@ -156,5 +156,3 @@ Actions are removed in v5 and replaced by a catch-all API route `[[...nextadmin]
 
 You should now have a working Next Admin v5 project.
 If you encounter any problems, please refer to the corresponding documentation or open a ticket on our Github repository
-
-

--- a/apps/example/app/[locale]/admin/[[...nextadmin]]/page.tsx
+++ b/apps/example/app/[locale]/admin/[[...nextadmin]]/page.tsx
@@ -3,7 +3,7 @@ import { options } from "@/options";
 import { prisma } from "@/prisma";
 import schema from "@/prisma/json-schema/json-schema.json";
 import { NextAdmin, PageProps } from "@premieroctet/next-admin";
-import { getNextAdminProps } from "@premieroctet/next-admin/dist/appRouter";
+import { getNextAdminProps } from "@premieroctet/next-admin/appRouter";
 import { Metadata, Viewport } from "next";
 import { getMessages } from "next-intl/server";
 

--- a/apps/example/app/[locale]/admin/custom/page.tsx
+++ b/apps/example/app/[locale]/admin/custom/page.tsx
@@ -1,5 +1,5 @@
 import { MainLayout } from "@premieroctet/next-admin";
-import { getMainLayoutProps } from "@premieroctet/next-admin/dist/appRouter";
+import { getMainLayoutProps } from "@premieroctet/next-admin/appRouter";
 import { options } from "../../../../options";
 import { prisma } from "../../../../prisma";
 

--- a/apps/example/app/api/admin/[[...nextadmin]]/route.ts
+++ b/apps/example/app/api/admin/[[...nextadmin]]/route.ts
@@ -1,7 +1,7 @@
 import { options } from "@/options";
 import { prisma } from "@/prisma";
 import schema from "@/prisma/json-schema/json-schema.json";
-import { createHandler } from "@premieroctet/next-admin/dist/appHandler";
+import { createHandler } from "@premieroctet/next-admin/appHandler";
 
 const { run } = createHandler({
   apiBasePath: "/api/admin",

--- a/apps/example/pages/api/pagerouter/admin/[[...nextadmin]].ts
+++ b/apps/example/pages/api/pagerouter/admin/[[...nextadmin]].ts
@@ -1,7 +1,7 @@
 import { options } from "@/pageRouterOptions";
 import { prisma } from "@/prisma";
 import schema from "@/prisma/json-schema/json-schema.json";
-import { createHandler } from "@premieroctet/next-admin/dist/pageHandler";
+import { createHandler } from "@premieroctet/next-admin/pageHandler";
 
 export const config = {
   api: {

--- a/apps/example/pages/pagerouter/admin/[[...nextadmin]].tsx
+++ b/apps/example/pages/pagerouter/admin/[[...nextadmin]].tsx
@@ -1,5 +1,5 @@
 import { AdminComponentProps, NextAdmin } from "@premieroctet/next-admin";
-import { getNextAdminProps } from "@premieroctet/next-admin/dist/pageRouter";
+import { getNextAdminProps } from "@premieroctet/next-admin/pageRouter";
 import { GetServerSideProps } from "next";
 import { options } from "../../../pageRouterOptions";
 import { prisma } from "../../../prisma";

--- a/apps/example/pages/pagerouter/admin/custom/index.tsx
+++ b/apps/example/pages/pagerouter/admin/custom/index.tsx
@@ -1,5 +1,5 @@
 import { MainLayout, MainLayoutProps } from "@premieroctet/next-admin";
-import { getMainLayoutProps } from "@premieroctet/next-admin/dist/pageRouter";
+import { getMainLayoutProps } from "@premieroctet/next-admin/pageRouter";
 import { GetServerSideProps } from "next";
 import { options } from "../../../../options";
 import { prisma } from "../../../../prisma";

--- a/apps/example/prisma/json-schema/json-schema.json
+++ b/apps/example/prisma/json-schema/json-schema.json
@@ -11,7 +11,10 @@
           "type": "string"
         },
         "hashedPassword": {
-          "type": "string"
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "name": {
           "type": [
@@ -76,8 +79,7 @@
         }
       },
       "required": [
-        "email",
-        "hashedPassword"
+        "email"
       ]
     },
     "Post": {

--- a/apps/example/tailwind.config.js
+++ b/apps/example/tailwind.config.js
@@ -146,5 +146,5 @@ module.exports = {
     },
   ],
   plugins: [require("@headlessui/tailwindcss")],
-  presets: [require("@premieroctet/next-admin/dist/preset")],
+  presets: [require("@premieroctet/next-admin/preset")],
 };

--- a/apps/example/tsconfig.json
+++ b/apps/example/tsconfig.json
@@ -5,7 +5,10 @@
       "@/*": ["*"]
     },
     "strictNullChecks": true,
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "declaration": false,
+    "declarationMap": false,
+    "composite": false
   },
   "extends": "tsconfig/nextjs.json",
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],

--- a/apps/example/tsconfig.json
+++ b/apps/example/tsconfig.json
@@ -2,20 +2,12 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@/*": [
-        "*"
-      ]
+      "@/*": ["*"]
     },
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "moduleResolution": "Bundler"
   },
   "extends": "tsconfig/nextjs.json",
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/packages/next-admin/package.json
+++ b/packages/next-admin/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@premieroctet/next-admin",
   "version": "5.5.0",
-  "main": "./dist/index.js",
   "description": "Next-Admin provides a customizable and turnkey admin dashboard for applications built with Next.js and powered by the Prisma ORM. It aims to simplify the development process by providing a turnkey admin system that can be easily integrated into your project.",
   "keywords": [
     "next.js",
@@ -27,7 +26,6 @@
     }
   ],
   "homepage": "https://next-admin.js.org/",
-  "types": "./dist/index.d.ts",
   "license": "MIT",
   "scripts": {
     "js": "tsc",
@@ -37,6 +35,38 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "tsc": "tsc --noEmit"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js"
+    },
+    "./appRouter": {
+      "import": "./dist/appRouter.js",
+      "types": "./dist/appRouter.d.ts",
+      "require": "./dist/appRouter.js"
+    },
+    "./appHandler": {
+      "import": "./dist/appHandler.js",
+      "types": "./dist/appHandler.d.ts",
+      "require": "./dist/appHandler.js"
+    },
+    "./pageRouter": {
+      "import": "./dist/pageRouter.js",
+      "types": "./dist/pageRouter.d.ts",
+      "require": "./dist/pageRouter.js"
+    },
+    "./pageHandler": {
+      "import": "./dist/pageHandler.js",
+      "types": "./dist/pageHandler.d.ts",
+      "require": "./dist/pageHandler.js"
+    },
+    "./preset": {
+      "import": "./dist/preset.js",
+      "types": "./dist/preset.d.ts",
+      "require": "./dist/preset.js"
+    }
   },
   "peerDependencies": {
     "@prisma/client": ">=4",

--- a/packages/next-admin/src/index.ts
+++ b/packages/next-admin/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./components/MainLayout";
 export * from "./components/NextAdmin";
+export * from "./components/inputs/BaseInput";
 export * from "./types";
 export * from "./exceptions/HookError";

--- a/packages/next-admin/tsconfig.json
+++ b/packages/next-admin/tsconfig.json
@@ -1,16 +1,7 @@
 {
   "extends": "tsconfig/react-library.json",
-  "include": [
-    "./src/pageRouter.ts",
-    "src/index.ts",
-    "./src/appRouter.ts",
-    "./src/actions/index.ts",
-    "./src/plugin.ts",
-    "./src/preset.ts",
-    "./src/appHandler.ts",
-    "./src/pageHandler.ts"
-  ],
-  "exclude": ["dist", "build", "node_modules"],
+  "include": ["./src/**/*"],
+  "exclude": ["dist", "build", "node_modules", "src/tests"],
   "compilerOptions": {
     "lib": ["dom"],
     "outDir": "dist",

--- a/packages/next-admin/tsconfig.json
+++ b/packages/next-admin/tsconfig.json
@@ -1,7 +1,14 @@
 {
   "extends": "tsconfig/react-library.json",
   "include": ["./src/**/*"],
-  "exclude": ["dist", "build", "node_modules", "src/tests"],
+  "exclude": [
+    "dist",
+    "build",
+    "node_modules",
+    "src/tests",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ],
   "compilerOptions": {
     "lib": ["dom"],
     "outDir": "dist",

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -17,7 +17,6 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "plugins": [{ "name": "next" }],
-    "moduleResolution": "Bundler"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -16,7 +16,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "plugins": [{ "name": "next" }]
+    "plugins": [{ "name": "next" }],
+    "moduleResolution": "Bundler"
   },
   "include": ["src", "next-env.d.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Title

Use package.json `exports` field.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#379 

## Description

This PR introduces a breaking change to the way we import stuff from inside the `dist folder`.

Example

`import { getNextAdminProps } from "@premieroctet/next-admin/dist/appRouter"`
now becomes
`import { getNextAdminProps } from "@premieroctet/next-admin/appRouter"`

## Impact

This is a breaking change, this impacts all the imports that are pointing to the `dist` folder. Those will need to be changed across all JS/TS files, and in the Tailwind config file aswell
