### PR TITLE
feat: add client actions

### DIFF
--- a/.changeset/perfect-toys-bathe.md
+++ b/.changeset/perfect-toys-bathe.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+feat: add client actions (#401)

--- a/apps/docs/pages/docs/api/components.mdx
+++ b/apps/docs/pages/docs/api/components.mdx
@@ -26,8 +26,14 @@ The button element accepts all the base `button` tag attributes and extends it w
     },
     {
       name: "asChild",
-      description:
-        "A boolean to render a [Radix Slot component](https://www.radix-ui.com/primitives/docs/utilities/slot)",
+      description: (
+        <>
+          A boolean to render a{" "}
+          <a href="https://www.radix-ui.com/primitives/docs/utilities/slot">
+            Radix Slot component
+          </a>
+        </>
+      ),
     },
     {
       name: "loading",

--- a/apps/docs/pages/docs/api/components.mdx
+++ b/apps/docs/pages/docs/api/components.mdx
@@ -1,0 +1,74 @@
+import OptionsTable from "../../../components/OptionsTable";
+
+# Components
+
+Next-Admin exports a set of UI components which are, for most of those, extending [Radix UI primitives](https://www.radix-ui.com/primitives). These components are available through the `@premieroctet/next-admin/components` import.
+
+## `Button`
+
+The button element accepts all the base `button` tag attributes and extends it with the following:
+
+<OptionsTable
+  options={[
+    {
+      name: "variant",
+      description:
+        "The button variant. Possible values are `default`, `destructive`, `destructiveOutline`, `outline`, `secondary`, `ghost`, `link`",
+      defaultValue: "default",
+    },
+    {
+      name: "size",
+      description: "The button size. Possible values are `default`, `sm`, `lg`",
+    },
+    {
+      name: "icon",
+      description: "A boolean indicating the presence of an icon",
+    },
+    {
+      name: "asChild",
+      description:
+        "A boolean to render a [Radix Slot component](https://www.radix-ui.com/primitives/docs/utilities/slot)",
+    },
+    {
+      name: "loading",
+      description: "A boolean to render a spinner",
+    },
+  ]}
+/>
+
+## `BaseInput`
+
+The input component rendered in the Form component. It accepts all the base `input` tag attributes.
+
+## `Switch`
+
+The [Radix Switch](https://www.radix-ui.com/primitives/docs/components/switch) component.
+
+## `Select`
+
+The [Radix Select](https://www.radix-ui.com/primitives/docs/components/select) component.
+
+## `Checkbox`
+
+An implementation of the [Radix Checkbox](https://www.radix-ui.com/primitives/docs/components/checkbox) component. It accepts all the props of the [Checkbox Root](https://www.radix-ui.com/primitives/docs/components/switch#root) component, and the following:
+
+<OptionsTable
+  options={[
+    {
+      name: "indeterminate",
+      description: "A boolean to render the checkbox in an indeterminate state",
+    },
+  ]}
+/>
+
+## `Dropdown`
+
+The [Radix Dropdown](https://www.radix-ui.com/primitives/docs/components/dropdown) component.
+
+## `Table`
+
+The [Radix Table](https://www.radix-ui.com/primitives/docs/components/table) component.
+
+## `Tooltip`
+
+The [Radix Tooltip](https://www.radix-ui.com/primitives/docs/components/tooltip) component.

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -114,9 +114,8 @@ By default, if no models are defined, they will all be displayed in the admin. I
       description: (
         <>
           {" "}
-          an array of actions (see <a href="#actions-property">
-            actions property
-          </a>)
+          an array of actions (see{" "}
+          <a href="#actions-property">actions property</a>)
         </>
       ),
     },
@@ -200,9 +199,8 @@ This property determines how your data is displayed in the [list View](/docs/glo
       description: (
         <>
           {" "}
-          define a set of Prisma filters that user can choose in list (see <a href="#listfilters-property">
-            filters
-          </a>)
+          define a set of Prisma filters that user can choose in list (see{" "}
+          <a href="#listfilters-property">filters</a>)
         </>
       ),
     },
@@ -315,6 +313,7 @@ The `exports` property is available in the `list` property. It's an object or an
 This property determines how your data is displayed in the [edit view](/docs/glossary#edit-view)
 
 {" "}
+
 <OptionsTable
   options={[
     {
@@ -323,10 +322,9 @@ This property determines how your data is displayed in the [edit view](/docs/glo
       description: (
         <>
           {" "}
-          an array of fields that are displayed in the form. It can also be an object
-          that will be displayed in the form of a notice (see <a href="#notice">
-            notice
-          </a>)
+          an array of fields that are displayed in the form. It can also be an
+          object that will be displayed in the form of a notice (see{" "}
+          <a href="#notice">notice</a>)
         </>
       ),
       defaultValue: "all scalar fields are displayed",
@@ -590,12 +588,38 @@ The `actions` property is an array of objects that allows you to define a set of
       description: "mandatory, action's unique identifier",
     },
     {
+      name: "type",
+      type: "String",
+      description:
+        "optional action type for client side actions, possible value is 'dialog'. By default action with no type is executed on the server",
+    },
+    {
+      name: "component",
+      type: "ReactElement",
+      description: (
+        <>
+          a React component that will be displayed in a dialog when the action
+          is triggered. Its mandatory if the action type is specified
+        </>
+      ),
+    },
+    {
+      name: "className",
+      type: "string",
+      description: (
+        <>
+          class name applied to the dialog displayed when the action type is set
+          to 'dialog'.
+        </>
+      ),
+    },
+    {
       name: "action",
       type: "Function",
       description: (
         <>
           an async function that will be triggered when selecting the action in
-          the dropdown. For App Router, it must be defined as a server action
+          the dropdown. Its mandatory if the action type is not specified
         </>
       ),
     },
@@ -732,9 +756,11 @@ Represents the props that are passed to the custom input component.
       description: (
         <>
           {" "}
-          a function taking a <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event">
+          a function taking a{" "}
+          <a href="https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/change_event">
             ChangeEvent
-          </a> as a parameter
+          </a>{" "}
+          as a parameter
         </>
       ),
     },
@@ -772,6 +798,131 @@ The `HookError` is an error that can be thrown in the `beforeDb` hook of the `ed
       type: "Object",
       description:
         "an error object that must contain at least an error property which is a string",
+    },
+  ]}
+/>
+
+## ClientActionDialogContentProps
+
+Represents the props that are passed to the custom dialog component.
+
+<OptionsTable
+  options={[
+    {
+      name: "resource",
+      type: "String",
+      description: "the current Prisma model name",
+    },
+    {
+      name: "resourceId",
+      type: "String | Number",
+      description: "the selected record id",
+    },
+    {
+      name: "data",
+      type: "Record<string, ListDataFieldValue>",
+      description:
+        "A record of row's properties with [ListDataFieldValue](#listdatafieldvalue) as value",
+    },
+    {
+      name: "onClose",
+      type: "Function",
+      description: "a function to close the dialog",
+    },
+  ]}
+/>
+
+## ListDataFieldValue
+
+Represents a formatted value used by Next-Admin. It will have different shapes depending of the data type.
+
+It will always have the following :
+
+<OptionsTable
+  options={[
+    {
+      name: "__nextadmin_formatted",
+      type: "ReactNode",
+      description:
+        "A React Node used to have a custom rendering of the field, if needed",
+    },
+  ]}
+/>
+
+### Scalar
+
+<OptionsTable
+  options={[
+    {
+      name: "type",
+      type: "`scalar`",
+      description: "The type of data. It is always `scalar`",
+    },
+    {
+      name: "value",
+      type: "String | Number | boolean",
+      description: "the value coming from the database",
+    },
+  ]}
+/>
+
+### Count
+
+<OptionsTable
+  options={[
+    {
+      name: "type",
+      type: "`count`",
+      description: "The type of data. It is always `count`",
+    },
+    {
+      name: "value",
+      type: "Number",
+      description: "the value coming from the database",
+    },
+  ]}
+/>
+
+### Link
+
+<OptionsTable
+  options={[
+    {
+      name: "type",
+      type: "`link`",
+      description: "The type of data. It is always `link`",
+    },
+    {
+      name: "value",
+      type: "object",
+      description: "the link data displayed in the link CTA",
+    },
+    {
+      name: "value.label",
+      type: "String",
+      description: "the link CTA label",
+    },
+    {
+      name: "value.url",
+      type: "String",
+      description: "the link CTA href",
+    },
+  ]}
+/>
+
+### Date
+
+<OptionsTable
+  options={[
+    {
+      name: "type",
+      type: "`date`",
+      description: "The type of data. It is always `date`",
+    },
+    {
+      name: "value",
+      type: "Date",
+      description: "the value coming from the database",
     },
   ]}
 />

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -822,7 +822,7 @@ Represents the props that are passed to the custom dialog component.
       name: "data",
       type: "Record<string, ListDataFieldValue>",
       description:
-        "A record of row's properties with [ListDataFieldValue](#listdatafieldvalue) as value",
+        "A record of row's properties with ListDataFieldValue as value",
     },
     {
       name: "onClose",

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -821,8 +821,12 @@ Represents the props that are passed to the custom dialog component.
     {
       name: "data",
       type: "Record<string, ListDataFieldValue>",
-      description:
-        "A record of row's properties with ListDataFieldValue as value",
+      description: (
+        <>
+          A record of row's properties with{" "}
+          <a href="#listdatafieldvalue">ListDataFieldValue</a> as value
+        </>
+      ),
     },
     {
       name: "onClose",

--- a/apps/example/components/UserDetailsDialogContent.tsx
+++ b/apps/example/components/UserDetailsDialogContent.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { ClientActionDialogContentProps } from "@premieroctet/next-admin";
+import Button from "@premieroctet/next-admin/components/radix/Button";
+
+type Props = ClientActionDialogContentProps<"User">;
+
+const UserDetailsDialog = ({ data, onClose }: Props) => {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-2">
+        <h2 className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default text-2xl font-semibold">
+          {data?.email.value as string}
+        </h2>
+        <p className="text-nextadmin-content-subtle dark:text-dark-nextadmin-content-subtle">
+          {data?.name.value as string}
+        </p>
+        <p className="text-nextadmin-content-subtle dark:text-dark-nextadmin-content-subtle">
+          {data?.role.value as string}
+        </p>
+      </div>
+      <div className="flex">
+        <Button variant="default" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default UserDetailsDialog;

--- a/apps/example/components/UserDetailsDialogContent.tsx
+++ b/apps/example/components/UserDetailsDialogContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { ClientActionDialogContentProps } from "@premieroctet/next-admin";
-import Button from "@premieroctet/next-admin/components/radix/Button";
+import { Button } from "@premieroctet/next-admin/components";
 
 type Props = ClientActionDialogContentProps<"User">;
 

--- a/apps/example/messages/en.json
+++ b/apps/example/messages/en.json
@@ -6,6 +6,9 @@
           "title": "Send email",
           "success": "Email sent successfully",
           "error": "Error while sending email"
+        },
+        "details": {
+          "title": "User details"
         }
       }
     },

--- a/apps/example/messages/fr.json
+++ b/apps/example/messages/fr.json
@@ -110,6 +110,9 @@
           "title": "Envoyer un email",
           "success": "Email envoyé avec succès",
           "error": "Erreur lors de l'envoi de l'email"
+        },
+        "details": {
+          "title": "Détails de l'utilisateur"
         }
       },
       "label": "Action",

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -168,7 +168,6 @@ export const options: NextAdminOptions = {
           id: "user-details",
           title: "actions.user.details.title",
           component: <UserDetailsDialog />,
-          className: "",
         },
       ],
     },

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -1,6 +1,7 @@
 import { NextAdminOptions } from "@premieroctet/next-admin";
 import DatePicker from "./components/DatePicker";
 import PasswordInput from "./components/PasswordInput";
+import UserDetailsDialog from "@/components/UserDetailsDialogContent";
 
 export const options: NextAdminOptions = {
   title: "⚡️ My Admin",
@@ -161,6 +162,13 @@ export const options: NextAdminOptions = {
           },
           successMessage: "actions.user.email.success",
           errorMessage: "actions.user.email.error",
+        },
+        {
+          type: "dialog",
+          id: "user-details",
+          title: "actions.user.details.title",
+          component: <UserDetailsDialog />,
+          className: "",
         },
       ],
     },

--- a/packages/next-admin/package.json
+++ b/packages/next-admin/package.json
@@ -66,6 +66,11 @@
       "import": "./dist/preset.js",
       "types": "./dist/preset.d.ts",
       "require": "./dist/preset.js"
+    },
+    "./components/*": {
+      "import": "./dist/components/*.js",
+      "types": "./dist/components/*.d.ts",
+      "require": "./dist/components/*.js"
     }
   },
   "peerDependencies": {

--- a/packages/next-admin/package.json
+++ b/packages/next-admin/package.json
@@ -67,10 +67,10 @@
       "types": "./dist/preset.d.ts",
       "require": "./dist/preset.js"
     },
-    "./components/*": {
-      "import": "./dist/components/*.js",
-      "types": "./dist/components/*.d.ts",
-      "require": "./dist/components/*.js"
+    "./components": {
+      "import": "./dist/components/index.js",
+      "types": "./dist/components/index.d.ts",
+      "require": "./dist/components/index.js"
     }
   },
   "peerDependencies": {

--- a/packages/next-admin/src/appHandler.ts
+++ b/packages/next-admin/src/appHandler.ts
@@ -2,7 +2,12 @@ import { createEdgeRouter } from "next-connect";
 import { NextRequest, NextResponse } from "next/server";
 import { handleOptionsSearch } from "./handlers/options";
 import { deleteResource, submitResource } from "./handlers/resources";
-import { CreateAppHandlerParams, Permission, RequestContext } from "./types";
+import {
+  CreateAppHandlerParams,
+  Permission,
+  RequestContext,
+  ServerAction,
+} from "./types";
 import { hasPermission } from "./utils/permissions";
 import {
   formatId,
@@ -63,10 +68,17 @@ export const createHandler = <P extends string = "nextadmin">({
         );
       }
 
+      if ("type" in modelAction && modelAction.type === "dialog") {
+        return NextResponse.json(
+          { error: "Action not found" },
+          { status: 404 }
+        );
+      }
+
       const body = await req.json();
 
       try {
-        await modelAction.action(body as string[] | number[]);
+        await (modelAction as ServerAction).action(body as string[] | number[]);
 
         return NextResponse.json({ ok: true });
       } catch (e) {

--- a/packages/next-admin/src/components/ActionDropdownItem.tsx
+++ b/packages/next-admin/src/components/ActionDropdownItem.tsx
@@ -1,18 +1,23 @@
 import clsx from "clsx";
+import { useClientDialog } from "../context/ClientDialogContext";
+import { useI18n } from "../context/I18nContext";
 import { useAction } from "../hooks/useAction";
 import { ModelAction, ModelName } from "../types";
 import { DropdownItem } from "./radix/Dropdown";
-import { useI18n } from "../context/I18nContext";
 
 type Props = {
-  action: ModelAction | Omit<ModelAction, "action">;
+  action: ModelAction<ModelName> | Omit<ModelAction<ModelName>, "action">;
   resource: ModelName;
   resourceIds: string[] | number[];
+  data?: any;
 };
 
-const ActionDropdownItem = ({ action, resource, resourceIds }: Props) => {
+const ActionDropdownItem = ({ action, resource, resourceIds, data }: Props) => {
   const { t } = useI18n();
   const { runAction } = useAction(resource, resourceIds);
+  const isClientAction =
+    "component" in action && "type" in action && action.type === "dialog";
+  const { open } = useClientDialog();
 
   return (
     <DropdownItem
@@ -23,7 +28,16 @@ const ActionDropdownItem = ({ action, resource, resourceIds }: Props) => {
       })}
       onClick={(evt) => {
         evt.stopPropagation();
-        runAction(action);
+        if (isClientAction) {
+          open({
+            actionId: action.id,
+            data: data,
+            resource: resource,
+            resourceId: resourceIds[0],
+          });
+        } else {
+          runAction(action);
+        }
       }}
     >
       {t(action.title)}

--- a/packages/next-admin/src/components/ActionsDropdown.tsx
+++ b/packages/next-admin/src/components/ActionsDropdown.tsx
@@ -15,7 +15,9 @@ import {
 } from "./radix/Dropdown";
 
 type Props = {
-  actions: Array<ModelAction | Omit<ModelAction, "action">>;
+  actions: Array<
+    ModelAction<ModelName> | Omit<ModelAction<ModelName>, "action">
+  >;
   selectedIds: string[] | number[];
   resource: ModelName;
   selectedCount?: number;

--- a/packages/next-admin/src/components/ClientActionDialog.tsx
+++ b/packages/next-admin/src/components/ClientActionDialog.tsx
@@ -1,0 +1,93 @@
+import { Transition, TransitionChild } from "@headlessui/react";
+import { cloneElement, Fragment } from "react";
+import { useClientDialog } from "../context/ClientDialogContext";
+import { useConfig } from "../context/ConfigContext";
+import {
+  AdminComponentProps,
+  ModelAction,
+  ModelName,
+  ServerAction,
+} from "../types";
+import {
+  DialogContent,
+  DialogOverlay,
+  DialogPortal,
+  DialogRoot,
+} from "./radix/Dialog";
+
+type Props = {
+  actionsMap: NonNullable<AdminComponentProps["actionsMap"]>;
+};
+
+const ClientActionDialog = ({ actionsMap }: Props) => {
+  const { data, isOpen, onClose, clearData } = useClientDialog();
+  const { options } = useConfig();
+
+  const action = data?.resource
+    ? (options?.model?.[data.resource]?.actions?.find(
+        (action: ModelAction<ModelName>) =>
+          action.id === data?.actionId &&
+          "type" in action &&
+          action.type === "dialog"
+      ) as Exclude<ModelAction<ModelName>, ServerAction>)
+    : null;
+
+  if (isOpen && !action) {
+    throw new Error("Action not found");
+  }
+
+  return (
+    <DialogRoot
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          onClose();
+        }
+      }}
+      modal
+    >
+      <DialogPortal forceMount>
+        <Transition show={isOpen} as="div">
+          <TransitionChild
+            as={Fragment}
+            enter="transition-opacity ease-in-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+            leave="transition-opacity ease-in-out duration-300"
+          >
+            <DialogOverlay forceMount />
+          </TransitionChild>
+          <TransitionChild
+            as={Fragment}
+            enter="transition-opacity ease-in-out duration-300"
+            enterFrom="opacity-0"
+            enterTo="opacity-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+            leave="transition-opacity ease-in-out duration-300"
+            afterLeave={clearData}
+          >
+            <DialogContent
+              className="max-w-xl md:left-[50%] md:top-[50%]"
+              forceMount
+            >
+              {action &&
+                actionsMap[action.id] &&
+                data &&
+                cloneElement(actionsMap[action.id], {
+                  data: data.data,
+                  resource: data.resource,
+                  resourceId: data.resourceId,
+                  onClose,
+                })}
+            </DialogContent>
+          </TransitionChild>
+        </Transition>
+      </DialogPortal>
+    </DialogRoot>
+  );
+};
+
+export default ClientActionDialog;

--- a/packages/next-admin/src/components/ClientActionDialog.tsx
+++ b/packages/next-admin/src/components/ClientActionDialog.tsx
@@ -1,5 +1,6 @@
 import { Transition, TransitionChild } from "@headlessui/react";
 import { cloneElement, Fragment } from "react";
+import clsx from "clsx";
 import { useClientDialog } from "../context/ClientDialogContext";
 import { useConfig } from "../context/ConfigContext";
 import {
@@ -70,7 +71,10 @@ const ClientActionDialog = ({ actionsMap }: Props) => {
             afterLeave={clearData}
           >
             <DialogContent
-              className="max-w-xl md:left-[50%] md:top-[50%]"
+              className={clsx(
+                "max-w-xl md:left-[50%] md:top-[50%]",
+                action?.className
+              )}
               forceMount
             >
               {action &&

--- a/packages/next-admin/src/components/List.tsx
+++ b/packages/next-admin/src/components/List.tsx
@@ -3,6 +3,7 @@ import { EllipsisVerticalIcon } from "@heroicons/react/24/outline";
 import { ColumnDef, RowSelectionState } from "@tanstack/react-table";
 import debounce from "lodash/debounce";
 import { ChangeEvent, useEffect, useState, useTransition } from "react";
+import clsx from "clsx";
 import { ITEMS_PER_PAGE } from "../config";
 import { useConfig } from "../context/ConfigContext";
 import { useI18n } from "../context/I18nContext";
@@ -41,6 +42,8 @@ import {
   SelectValue,
 } from "./radix/Select";
 import ActionDropdownItem from "./ActionDropdownItem";
+import ClientDialogProvider from "../context/ClientDialogContext";
+import ClientActionDialog from "./ClientActionDialog";
 
 export type ListProps = {
   resource: ModelName;
@@ -51,6 +54,7 @@ export type ListProps = {
   actions?: AdminComponentProps["actions"];
   icon?: ModelIcon;
   schema: Schema;
+  actionsMap: NonNullable<AdminComponentProps["actionsMap"]>;
 };
 
 function List({
@@ -62,6 +66,7 @@ function List({
   title,
   icon,
   schema,
+  actionsMap,
 }: ListProps) {
   const { router, query } = useRouterInternal();
   const [isPending, startTransition] = useTransition();
@@ -169,20 +174,20 @@ function List({
                     action={action}
                     resourceIds={[row.original[idProperty].value as string]}
                     resource={resource}
+                    data={row.original}
                   />
                 );
               })}
-              <DropdownItem asChild>
-                <Button
-                  variant="destructiveOutline"
-                  className="h-6 w-full"
-                  onClick={(evt) => {
-                    evt.stopPropagation();
-                    deleteItems([row.original[idProperty].value as string]);
-                  }}
-                >
-                  {t("list.row.actions.delete.label")}
-                </Button>
+              <DropdownItem
+                className={clsx(
+                  "cursor-pointer rounded-md px-2 py-1 text-red-700 hover:bg-red-50 dark:text-red-400"
+                )}
+                onClick={(evt) => {
+                  evt.stopPropagation();
+                  deleteItems([row.original[idProperty].value as string]);
+                }}
+              >
+                {t("list.row.actions.delete.label")}
               </DropdownItem>
             </DropdownContent>
           </DropdownBody>
@@ -210,7 +215,7 @@ function List({
   };
 
   return (
-    <>
+    <ClientDialogProvider>
       <div className="flow-root h-full">
         <ListHeader
           title={title}
@@ -298,7 +303,8 @@ function List({
           ) : null}
         </div>
       </div>
-    </>
+      <ClientActionDialog actionsMap={actionsMap} />
+    </ClientDialogProvider>
   );
 }
 

--- a/packages/next-admin/src/components/ListHeader.tsx
+++ b/packages/next-admin/src/components/ListHeader.tsx
@@ -70,7 +70,7 @@ export default function ListHeader({
   const selectedRowsCount = Object.keys(selectedRows).length;
 
   const actions = useMemo(() => {
-    const defaultActions: ModelAction[] = canDelete
+    const defaultActions: ModelAction<ModelName>[] = canDelete
       ? [
           {
             id: SPECIFIC_IDS_TO_RUN_ACTION.DELETE,
@@ -139,7 +139,10 @@ export default function ListHeader({
           <AdvancedSearchButton resource={resource} schema={schema} />
           {Boolean(selectedRowsCount) && !!actions.length && (
             <ActionsDropdown
-              actions={actions}
+              // We don't want client actions in the list header
+              actions={actions.filter(
+                (action) => !("type" in action && action.type === "dialog")
+              )}
               resource={resource}
               selectedIds={getSelectedRowsIds()}
               selectedCount={selectedRowsCount}

--- a/packages/next-admin/src/components/NextAdmin.tsx
+++ b/packages/next-admin/src/components/NextAdmin.tsx
@@ -1,7 +1,7 @@
 import dynamic from "next/dynamic";
 import { AdminComponentProps, CustomUIProps } from "../types";
 import { getSchemaForResource } from "../utils/jsonSchema";
-import { getCustomInputs } from "../utils/options";
+import { getClientActionDialogs, getCustomInputs } from "../utils/options";
 import Dashboard from "./Dashboard";
 import Form from "./Form";
 import List from "./List";
@@ -37,6 +37,7 @@ export function NextAdmin({
   resourcesIcons,
   user,
   externalLinks,
+  actionsMap: actionsMapProp,
 }: AdminComponentProps & CustomUIProps) {
   if (!isAppDir && !options) {
     throw new Error(
@@ -55,6 +56,9 @@ export function NextAdmin({
 
   const renderMainComponent = () => {
     if (Array.isArray(data) && resource && typeof total != "undefined") {
+      const actionsMap = isAppDir
+        ? actionsMapProp
+        : getClientActionDialogs(resource!, options!);
       return (
         <List
           key={resource}
@@ -66,6 +70,7 @@ export function NextAdmin({
           actions={actions}
           icon={resourceIcon}
           schema={schema!}
+          actionsMap={actionsMap ?? {}}
         />
       );
     }

--- a/packages/next-admin/src/components/advancedSearch/AdvancedSearchModal.tsx
+++ b/packages/next-admin/src/components/advancedSearch/AdvancedSearchModal.tsx
@@ -122,10 +122,7 @@ const AdvancedSearchModal = ({ isOpen, onClose, resource, schema }: Props) => {
             leaveTo="opacity-0"
             leave="transition-opacity ease-in-out duration-300"
           >
-            <DialogOverlay
-              forceMount
-              className="bg-nextadmin-background-default/70 dark:bg-dark-nextadmin-background-default/70 fixed inset-0"
-            />
+            <DialogOverlay forceMount />
           </TransitionChild>
           <TransitionChild
             as={Fragment}
@@ -138,7 +135,7 @@ const AdvancedSearchModal = ({ isOpen, onClose, resource, schema }: Props) => {
           >
             <DialogContent
               forceMount
-              className="fixed inset-x-0 max-w-xl md:left-[50%] md:top-[50%]"
+              className="max-w-xl md:left-[50%] md:top-[50%]"
             >
               <div className="flex flex-col gap-4">
                 <DialogTitle>{t("search.advanced.title")}</DialogTitle>

--- a/packages/next-admin/src/components/index.ts
+++ b/packages/next-admin/src/components/index.ts
@@ -1,0 +1,8 @@
+export { Button, type ButtonProps, buttonVariants } from "./radix/Button";
+export { default as BaseInput } from "./inputs/BaseInput";
+export * from "./radix/Switch";
+export * from "./radix/Select";
+export { default as Checkbox } from "./radix/Checkbox";
+export * from "./radix/Dropdown";
+export * from "./radix/Table";
+export * from "./radix/Tooltip";

--- a/packages/next-admin/src/components/radix/Dialog.tsx
+++ b/packages/next-admin/src/components/radix/Dialog.tsx
@@ -14,7 +14,10 @@ export const DialogOverlay = forwardRef<
   return (
     <Dialog.Overlay
       className={twMerge(
-        clsx("fixed inset-0 z-[51] bg-black/20 dark:bg-white/20", className)
+        clsx(
+          "bg-nextadmin-background-default/70 dark:bg-dark-nextadmin-background-default/70 fixed inset-0 z-[51]",
+          className
+        )
       )}
       ref={ref}
       {...props}

--- a/packages/next-admin/src/components/radix/Dropdown.tsx
+++ b/packages/next-admin/src/components/radix/Dropdown.tsx
@@ -1,6 +1,7 @@
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import clsx from "clsx";
 import { ComponentProps, ElementRef, forwardRef } from "react";
+import { twMerge } from "tailwind-merge";
 
 export const Dropdown = DropdownMenu.Root;
 
@@ -38,9 +39,11 @@ export const DropdownContent = forwardRef<
 >(({ className, ...props }, ref) => {
   return (
     <DropdownMenu.Content
-      className={clsx(
-        "bg-nextadmin-background-default dark:bg-dark-nextadmin-background-subtle z-50 rounded-md shadow-lg focus:outline-none focus:ring-0",
-        className
+      className={twMerge(
+        clsx(
+          "bg-nextadmin-background-default dark:bg-dark-nextadmin-background-subtle z-50 rounded-md shadow-lg focus:outline-none focus:ring-0",
+          className
+        )
       )}
       ref={ref}
       {...props}
@@ -56,9 +59,11 @@ export const DropdownItem = forwardRef<
 >(({ className, ...props }, ref) => {
   return (
     <DropdownMenu.Item
-      className={clsx(
-        "text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted dark:hover:bg-dark-nextadmin-background-muted hover:bg-nextadmin-background-muted group text-sm focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
-        className
+      className={twMerge(
+        clsx(
+          "text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted dark:hover:bg-dark-nextadmin-background-muted hover:bg-nextadmin-background-muted group text-sm focus:outline-none focus-visible:outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
+          className
+        )
       )}
       ref={ref}
       {...props}
@@ -74,7 +79,9 @@ export const DropdownLabel = forwardRef<
 >(({ className, ...props }, ref) => {
   return (
     <DropdownMenu.Label
-      className={clsx("group text-sm font-medium text-gray-900", className)}
+      className={twMerge(
+        clsx("group text-sm font-medium text-gray-900", className)
+      )}
       ref={ref}
       {...props}
     />
@@ -89,7 +96,12 @@ export const DropdownSeparator = forwardRef<
 >(({ className, ...props }, ref) => {
   return (
     <DropdownMenu.Separator
-      className={clsx("m-1 h-px bg-nextadmin-border-strong dark:bg-dark-nextadmin-border-strong", className)}
+      className={twMerge(
+        clsx(
+          "bg-nextadmin-border-strong dark:bg-dark-nextadmin-border-strong m-1 h-px",
+          className
+        )
+      )}
       ref={ref}
       {...props}
     />

--- a/packages/next-admin/src/context/ClientDialogContext.tsx
+++ b/packages/next-admin/src/context/ClientDialogContext.tsx
@@ -1,0 +1,56 @@
+import { createContext, PropsWithChildren, useContext, useState } from "react";
+import {
+  AdminComponentProps,
+  ListDataFieldValue,
+  Model,
+  ModelName,
+} from "../types";
+
+type ClientDialogData = {
+  resource: ModelName;
+  resourceId: string | number;
+  actionId: string;
+  data: Record<keyof Model<ModelName>, ListDataFieldValue>;
+};
+
+type ClientDialogContextType = {
+  isOpen: boolean;
+  onClose: () => void;
+  open: (data: ClientDialogData) => void;
+  data: ClientDialogData | null;
+  clearData: () => void;
+};
+
+const ClientDialogContext = createContext<ClientDialogContextType>(
+  {} as ClientDialogContextType
+);
+
+const ClientDialogProvider = ({ children }: PropsWithChildren) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [dialogData, setDialogData] = useState<ClientDialogData | null>(null);
+
+  const onClose = () => {
+    setIsOpen(false);
+  };
+
+  const open = (data: ClientDialogData) => {
+    setIsOpen(true);
+    setDialogData(data);
+  };
+
+  const clearData = () => {
+    setDialogData(null);
+  };
+
+  return (
+    <ClientDialogContext.Provider
+      value={{ isOpen, onClose, open, data: dialogData, clearData }}
+    >
+      {children}
+    </ClientDialogContext.Provider>
+  );
+};
+
+export const useClientDialog = () => useContext(ClientDialogContext);
+
+export default ClientDialogProvider;

--- a/packages/next-admin/src/hooks/useAction.ts
+++ b/packages/next-admin/src/hooks/useAction.ts
@@ -1,4 +1,4 @@
-import { ModelAction, ModelName } from "../types";
+import { ClientAction, ModelAction, ModelName } from "../types";
 import { useI18n } from "../context/I18nContext";
 import { useConfig } from "../context/ConfigContext";
 import { useMessage } from "../context/MessageContext";
@@ -13,7 +13,9 @@ export const useAction = (resource: ModelName, ids: string[] | number[]) => {
   const { showMessage } = useMessage();
 
   const runAction = async (
-    modelAction: ModelAction | Omit<ModelAction, "action">
+    modelAction:
+      | Exclude<ModelAction<ModelName>, ClientAction<ModelName>>
+      | Omit<Exclude<ModelAction<ModelName>, ClientAction<ModelName>>, "action">
   ) => {
     try {
       if (

--- a/packages/next-admin/src/index.ts
+++ b/packages/next-admin/src/index.ts
@@ -1,5 +1,4 @@
 export * from "./components/MainLayout";
 export * from "./components/NextAdmin";
-export * from "./components/inputs/BaseInput";
 export * from "./types";
 export * from "./exceptions/HookError";

--- a/packages/next-admin/src/pageHandler.ts
+++ b/packages/next-admin/src/pageHandler.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from "next";
 import { NextHandler, createRouter } from "next-connect";
 import { handleOptionsSearch } from "./handlers/options";
 import { deleteResource, submitResource } from "./handlers/resources";
-import { NextAdminOptions, Permission } from "./types";
+import { NextAdminOptions, Permission, ServerAction } from "./types";
 import { hasPermission } from "./utils/permissions";
 import {
   formatId,
@@ -88,6 +88,10 @@ export const createHandler = <P extends string = "nextadmin">({
         return res.status(404).json({ error: "Action not found" });
       }
 
+      if ("type" in modelAction && modelAction.type === "dialog") {
+        return res.status(404).json({ error: "Action not found" });
+      }
+
       let body;
 
       try {
@@ -97,7 +101,7 @@ export const createHandler = <P extends string = "nextadmin">({
       }
 
       try {
-        await modelAction.action(body);
+        await (modelAction as ServerAction).action(body);
 
         return res.json({ ok: true });
       } catch (e) {
@@ -160,7 +164,9 @@ export const createHandler = <P extends string = "nextadmin">({
           });
         }
 
-        response = (await editOptions?.hooks?.afterDb?.(response, mode, req)) ?? response;
+        response =
+          (await editOptions?.hooks?.afterDb?.(response, mode, req)) ??
+          response;
 
         return res.status(id ? 200 : 201).json(response);
       } catch (e) {

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -532,13 +532,28 @@ type CustomFieldsType = {
 
 export type ActionStyle = "default" | "destructive";
 
-export type ModelAction = {
-  title: string;
-  id: string;
+export type ServerAction = {
   action: (ids: string[] | number[]) => Promise<void>;
-  style?: ActionStyle;
   successMessage?: string;
   errorMessage?: string;
+};
+
+export type ClientAction<T extends ModelName> = {
+  type: "dialog";
+  component: React.ReactElement<ClientActionDialogContentProps<T>>;
+  /**
+   * Class name to apply to the dialog content
+   */
+  className?: string;
+};
+
+export type ModelAction<T extends ModelName> = (
+  | ServerAction
+  | ClientAction<T>
+) & {
+  title: string;
+  id: string;
+  style?: ActionStyle;
 };
 
 export type ModelIcon = keyof typeof OutlineIcons;
@@ -574,7 +589,7 @@ export type ModelOptions<T extends ModelName> = {
      * an object containing the aliases of the model fields as keys, and the field name.
      */
     aliases?: Partial<Record<Field<P>, string>> & { [key: string]: string };
-    actions?: ModelAction[];
+    actions?: ModelAction<T>[];
     /**
      * the outline HeroIcon name displayed in the sidebar and pages title
      * @type ModelIcon
@@ -801,7 +816,8 @@ export type AdminComponentProps = {
    */
   pageComponent?: React.ComponentType;
   customPages?: Array<{ title: string; path: string; icon?: ModelIcon }>;
-  actions?: Omit<ModelAction, "action">[];
+  actions?: Omit<ModelAction<ModelName>, "action">[];
+  actionsMap?: Record<string, React.ReactElement>;
   translations?: Translations;
   /**
    * Global admin title
@@ -1050,3 +1066,10 @@ export type FormProps = {
   icon?: ModelIcon;
   resourcesIdProperty: Record<ModelName, string>;
 };
+
+export type ClientActionDialogContentProps<T extends ModelName> = Partial<{
+  resource: ModelName;
+  resourceId: string | number;
+  data: Record<keyof Model<T>, ListDataFieldValue>;
+  onClose?: () => void;
+}>;

--- a/packages/next-admin/src/utils/options.ts
+++ b/packages/next-admin/src/utils/options.ts
@@ -27,3 +27,24 @@ export const getCustomInputs = (
     return acc;
   }, {});
 };
+
+export const getClientActionDialogs = (
+  model: ModelName,
+  options?: NextAdminOptions
+) => {
+  const actions = options?.model?.[model]?.actions;
+  const actionsMap: Record<string, React.ReactElement> = {};
+
+  actions?.forEach((action) => {
+    if (
+      "component" in action &&
+      "type" in action &&
+      action.type === "dialog" &&
+      action.component
+    ) {
+      actionsMap[action.id] = action.component;
+    }
+  });
+
+  return actionsMap;
+};

--- a/packages/next-admin/src/utils/props.ts
+++ b/packages/next-admin/src/utils/props.ts
@@ -10,7 +10,7 @@ import {
   ModelName,
   NextAdminOptions,
 } from "../types";
-import { getCustomInputs } from "./options";
+import { getClientActionDialogs, getCustomInputs } from "./options";
 import { getDataItem, getMappedDataList } from "./prisma";
 import {
   applyVisiblePropertiesInSchema,
@@ -97,6 +97,7 @@ export async function getPropsFromParams({
 
   // We don't need to pass the action function to the component
   const actions = options?.model?.[resource]?.actions?.map((action) => {
+    // @ts-expect-error
     const { action: _, ...actionRest } = action;
     return actionRest;
   });
@@ -133,6 +134,10 @@ export async function getPropsFromParams({
         appDir: isAppDir,
       });
 
+      const actionsMap = isAppDir
+        ? getClientActionDialogs(resource, options)
+        : undefined;
+
       return {
         ...defaultProps,
         resource,
@@ -141,6 +146,7 @@ export async function getPropsFromParams({
         error: error ?? (searchParams?.error as string),
         schema,
         actions: isAppDir ? actions : undefined,
+        actionsMap,
       };
     }
     case Page.EDIT: {

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -8,7 +8,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "inlineSources": false,
-    "isolatedModules": true,
+    "isolatedModules": false,
     "moduleResolution": "node",
     "noUnusedLocals": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
## Title

Add the ability to render client component through list row actions

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#401 

## Description

Currently, row actions only allows to execute a set of actions that are executed on the server side through an API call. This is limiting when we want to visualize some stuff on the client side. This PR allows defining client only actions that accept a component property (like custom inputs) and renders it in a Dialog box.

## Screenshots

![image](https://github.com/user-attachments/assets/4067ae42-8f14-48c0-8b9e-7341bd915e82)
![image](https://github.com/user-attachments/assets/d61c4dd5-2e22-4b2e-9f8a-4409c728c7bd)

