### PR TITLE
fix: correctly display path in advanced search

### DIFF
--- a/.changeset/breezy-cups-call.md
+++ b/.changeset/breezy-cups-call.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: correctly display path in advanced search

--- a/packages/next-admin/src/components/advancedSearch/AdvancedSearchDropdownItem.tsx
+++ b/packages/next-admin/src/components/advancedSearch/AdvancedSearchDropdownItem.tsx
@@ -10,6 +10,7 @@ import {
   UIQueryBlock,
 } from "../../utils/advancedSearch";
 import { useConfig } from "../../context/ConfigContext";
+import { useI18n } from "../../context/I18nContext";
 
 type Props = {
   property: string;
@@ -29,6 +30,7 @@ const AdvancedSearchDropdownItem = ({
   displayPath,
 }: Props) => {
   const { options } = useConfig();
+  const { t } = useI18n();
   const schemaDef = schema.definitions[resource];
   const schemaProperty =
     schemaDef.properties[property as keyof typeof schemaDef.properties];
@@ -66,8 +68,11 @@ const AdvancedSearchDropdownItem = ({
   }, [hasChildren, schemaProperty, schema]);
 
   const aliases = options?.model?.[resource]?.aliases;
-  const displayedProperty =
-    aliases?.[property as keyof typeof aliases] ?? property;
+  const displayedProperty = t(
+    `model.${resource}.fields.${property}`,
+    {},
+    aliases?.[property as keyof typeof aliases] ?? property
+  );
 
   const onClick = (evt: MouseEvent<HTMLDivElement>) => {
     if (hasChildren) {

--- a/packages/next-admin/src/components/radix/Dialog.tsx
+++ b/packages/next-admin/src/components/radix/Dialog.tsx
@@ -15,7 +15,7 @@ export const DialogOverlay = forwardRef<
     <Dialog.Overlay
       className={twMerge(
         clsx(
-          "bg-zinc-950/25 dark:bg-zinc-950/50 fixed inset-0 z-[51]",
+          "fixed inset-0 z-[51] bg-zinc-950/25 dark:bg-zinc-950/50",
           className
         )
       )}
@@ -33,7 +33,7 @@ export const DialogContent = forwardRef<
     <Dialog.Content
       className={twMerge(
         clsx(
-          "text-nextadmin-content-emphasis dark:text-dark-nextadmin-content-emphasis border-nextadmin-border-strong dark:border-dark-nextadmin-border-strong bg-nextadmin-background-default dark:bg-dark-nextadmin-background-default fixed top-[50%] z-[52] w-full translate-y-[-50%] border p-6 md:left-[50%] md:w-[50vw] md:translate-x-[-50%] bg-white shadow-lg rounded-2xl",
+          "text-nextadmin-content-emphasis dark:text-dark-nextadmin-content-emphasis border-nextadmin-border-strong dark:border-dark-nextadmin-border-strong bg-nextadmin-background-default dark:bg-dark-nextadmin-background-default fixed top-[50%] z-[52] w-full translate-y-[-50%] rounded-lg border bg-white p-6 shadow-lg md:left-[50%] md:w-[50vw] md:translate-x-[-50%]",
           className
         )
       )}

--- a/packages/next-admin/src/context/I18nContext.tsx
+++ b/packages/next-admin/src/context/I18nContext.tsx
@@ -6,12 +6,14 @@ type Props = {
   translations: Translations;
 };
 
+export type TranslationFn = (
+  key: string,
+  options?: { [key: string]: any },
+  fallback?: string
+) => string;
+
 const I18nContext = createContext<{
-  t: (
-    key: string,
-    options?: { [key: string]: any },
-    fallback?: string
-  ) => string;
+  t: TranslationFn;
 }>({
   t: () => "",
 });
@@ -20,7 +22,7 @@ export const I18nProvider = ({
   translations,
   children,
 }: PropsWithChildren<Props>) => {
-  const t = (
+  const t: TranslationFn = (
     key: string,
     options?: { [key: string]: any },
     fallback?: string

--- a/packages/next-admin/src/hooks/useAdvancedSearch.ts
+++ b/packages/next-admin/src/hooks/useAdvancedSearch.ts
@@ -6,6 +6,7 @@ import {
 } from "../utils/advancedSearch";
 import { useRouterInternal } from "./useRouterInternal";
 import { ModelName, Schema } from "../types";
+import { useConfig } from "../context/ConfigContext";
 
 type UseAdvancedSearchParams<M extends ModelName> = {
   resource: M;
@@ -17,6 +18,7 @@ const useAdvancedSearch = <M extends ModelName>({
   schema,
 }: UseAdvancedSearchParams<M>) => {
   const { router, query } = useRouterInternal();
+  const { options } = useConfig();
   const [uiBlocks, setUiBlocks] = useState(() => {
     if (query.q) {
       const blocks = validateQuery(query.q);
@@ -25,7 +27,11 @@ const useAdvancedSearch = <M extends ModelName>({
         return null;
       }
 
-      return buildUIBlocks(blocks, { resource, schema });
+      return buildUIBlocks(blocks, {
+        resource,
+        schema,
+        options: options?.model,
+      });
     }
   });
 

--- a/packages/next-admin/src/hooks/useAdvancedSearch.ts
+++ b/packages/next-admin/src/hooks/useAdvancedSearch.ts
@@ -7,6 +7,7 @@ import {
 import { useRouterInternal } from "./useRouterInternal";
 import { ModelName, Schema } from "../types";
 import { useConfig } from "../context/ConfigContext";
+import { useI18n } from "../context/I18nContext";
 
 type UseAdvancedSearchParams<M extends ModelName> = {
   resource: M;
@@ -19,6 +20,7 @@ const useAdvancedSearch = <M extends ModelName>({
 }: UseAdvancedSearchParams<M>) => {
   const { router, query } = useRouterInternal();
   const { options } = useConfig();
+  const { t } = useI18n();
   const [uiBlocks, setUiBlocks] = useState(() => {
     if (query.q) {
       const blocks = validateQuery(query.q);
@@ -31,6 +33,7 @@ const useAdvancedSearch = <M extends ModelName>({
         resource,
         schema,
         options: options?.model,
+        t,
       });
     }
   });

--- a/packages/next-admin/src/utils/advancedSearch.test.ts
+++ b/packages/next-admin/src/utils/advancedSearch.test.ts
@@ -153,6 +153,7 @@ describe("advancedSearch", () => {
         canHaveChildren: false,
         internalPath: "[0]",
         nullable: true,
+        displayPath: "test",
       },
       {
         type: "filter",
@@ -164,6 +165,7 @@ describe("advancedSearch", () => {
         canHaveChildren: false,
         internalPath: "[1]",
         nullable: true,
+        displayPath: "test",
       },
       {
         type: "filter",
@@ -175,6 +177,7 @@ describe("advancedSearch", () => {
         canHaveChildren: false,
         internalPath: "[2]",
         nullable: true,
+        displayPath: "test",
       },
       {
         type: "filter",
@@ -186,6 +189,7 @@ describe("advancedSearch", () => {
         canHaveChildren: false,
         internalPath: "[3]",
         nullable: false,
+        displayPath: "test2",
       },
       {
         type: "filter",
@@ -197,6 +201,7 @@ describe("advancedSearch", () => {
         canHaveChildren: false,
         internalPath: "[4]",
         nullable: false,
+        displayPath: "test5 → test6",
       },
       {
         type: "filter",
@@ -208,6 +213,7 @@ describe("advancedSearch", () => {
         canHaveChildren: false,
         internalPath: "[5]",
         nullable: false,
+        displayPath: "test5 → some",
       },
       {
         type: "and",
@@ -224,6 +230,7 @@ describe("advancedSearch", () => {
             canHaveChildren: false,
             internalPath: "[6].children[0]",
             nullable: false,
+            displayPath: "test3 → test",
           },
           {
             type: "filter",
@@ -235,6 +242,7 @@ describe("advancedSearch", () => {
             canHaveChildren: false,
             internalPath: "[6].children[1]",
             nullable: false,
+            displayPath: "test3 → test2",
           },
           {
             type: "or",
@@ -251,6 +259,7 @@ describe("advancedSearch", () => {
                 canHaveChildren: false,
                 internalPath: "[6].children[2].children[0]",
                 nullable: false,
+                displayPath: "test5 → test6",
               },
             ],
           },
@@ -266,6 +275,7 @@ describe("advancedSearch", () => {
         canHaveChildren: false,
         internalPath: "[7]",
         nullable: false,
+        displayPath: "testBool",
       },
       {
         type: "filter",
@@ -277,6 +287,7 @@ describe("advancedSearch", () => {
         canHaveChildren: false,
         internalPath: "[8]",
         nullable: true,
+        displayPath: "testNull",
       },
       {
         type: "filter",
@@ -288,6 +299,7 @@ describe("advancedSearch", () => {
         canHaveChildren: false,
         internalPath: "[9]",
         nullable: false,
+        displayPath: "testArray",
       },
     ];
 
@@ -322,6 +334,7 @@ describe("advancedSearch", () => {
         canHaveChildren: false,
         internalPath: "[0]",
         nullable: false,
+        displayPath: "test2",
       },
     ];
 

--- a/packages/next-admin/src/utils/advancedSearch.ts
+++ b/packages/next-admin/src/utils/advancedSearch.ts
@@ -2,6 +2,7 @@ import z from "zod";
 import set from "lodash.set";
 import get from "lodash.get";
 import { ModelName, ModelOptions, Schema, SchemaModel } from "../types";
+import { TranslationFn } from "../context/I18nContext";
 
 export type QueryCondition =
   | "equals"
@@ -238,7 +239,13 @@ export const buildUIBlocks = <M extends ModelName>(
     resource,
     schema,
     options,
-  }: { resource: M; schema: Schema; options?: ModelOptions<ModelName> },
+    t,
+  }: {
+    resource: M;
+    schema: Schema;
+    options?: ModelOptions<ModelName>;
+    t?: TranslationFn;
+  },
   fields: string[] = [],
   displayFields: string[] = []
 ): UIQueryBlock[] => {
@@ -267,7 +274,10 @@ export const buildUIBlocks = <M extends ModelName>(
               key as keyof typeof resourceInSchema.properties
             ];
           const conditions = Object.entries(value as Filter);
-          const displayKey = options?.[resource]?.aliases?.[key] ?? key;
+          const displayKeyFallback = options?.[resource]?.aliases?.[key] ?? key;
+          const displayKey =
+            t?.(`model.${resource}.fields.${key}`, {}, displayKeyFallback) ??
+            displayKeyFallback;
 
           if (schemaProperty) {
             // @ts-expect-error

--- a/packages/next-admin/src/utils/advancedSearch.ts
+++ b/packages/next-admin/src/utils/advancedSearch.ts
@@ -286,6 +286,7 @@ export const buildUIBlocks = <M extends ModelName>(
                   contentType: contentType,
                   canHaveChildren: false,
                   nullable: isFieldNullable(schemaProperty.type),
+                  displayPath: [...fields, key].join(" → "),
                 };
               } else {
                 let isArrayConditionKey = conditionKey === "some";


### PR DESCRIPTION
## Title

Correctly display path in advanced search. The path was not displaying correctly after doing an advanced search and refreshing the page, or simply re-opening the modal.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement
