### PR TITLE
fix: CLI for page router, locale in page router props

### DIFF
--- a/.changeset/fuzzy-socks-visit.md
+++ b/.changeset/fuzzy-socks-visit.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: pass locale to page router props (#452)

--- a/.changeset/honest-emus-breathe.md
+++ b/.changeset/honest-emus-breathe.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin-cli": patch
+---
+
+fix: update for page router

--- a/apps/docs/pages/docs/getting-started.mdx
+++ b/apps/docs/pages/docs/getting-started.mdx
@@ -217,18 +217,18 @@ Add the `babel-plugin-superjson-next` plugin to your `.babelrc` file:
 <Tabs items={["yarn", "npm", "pnpm"]}>
   <Tabs.Tab>
     ```bash
-yarn add -E -D next-superjson-plugin@0.6.1 superjson
+yarn add -D next-superjson-plugin superjson
     ```
 
   </Tabs.Tab>
   <Tabs.Tab>
     ```bash
-npm install --save-dev -E next-superjson-plugin@0.6.1 superjson
+npm install --save-dev next-superjson-plugin superjson
     ```
   </Tabs.Tab>
   <Tabs.Tab>
     ```bash
-pnpm install -E -D next-superjson-plugin@0.6.1 superjson
+pnpm install -D next-superjson-plugin superjson
     ```
   </Tabs.Tab>
 </Tabs>

--- a/apps/docs/pages/docs/getting-started.mdx
+++ b/apps/docs/pages/docs/getting-started.mdx
@@ -150,7 +150,6 @@ Next-Admin uses a dynamic route `[[...nextadmin]]` to handle all the admin route
     import { GetServerSideProps } from "next";
     import { prisma } from " @/prisma";
     import schema from "@/prisma/json-schema/json-schema.json";
-    import "@/styles.css";
 
     export default function Admin(props: AdminComponentProps) {
       return (
@@ -174,6 +173,9 @@ Next-Admin uses a dynamic route `[[...nextadmin]]` to handle all the admin route
 
     <Callout type="info">
       Do not forget to add the `options` prop to `<NextAdmin />` component and `getNextAdminProps` function, if you are using it.
+    </Callout>
+    <Callout type="info">
+      Your CSS file should be imported in the `_app.js` / `_app.tsx` file. This is mandatory per the [Next.js documentation](https://nextjs.org/docs/messages/css-global). In most apps, you might have a different tailwind configuration living with the Next-Admin one. In that case, to avoid any conflicts, you can create an [App Router layout file](https://nextjs.org/docs/app/building-your-application/routing/layouts-and-templates#layouts) which imports the CSS file.
     </Callout>
 
     #### SuperJson configuration

--- a/packages/cli/src/templates/page_router_page.mustache
+++ b/packages/cli/src/templates/page_router_page.mustache
@@ -4,7 +4,6 @@ import { getNextAdminProps } from "@premieroctet/next-admin/pageRouter";
 import prisma from "{{prismaClientPath}}";
 import schema from "{{jsonSchemaPath}}";
 import options from "{{optionsPath}}";
-import "{{stylesPath}}";
  
 export default function Admin(props{{#isTypescript}}: AdminComponentProps{{/isTypescript}}) {
   return (
@@ -21,6 +20,6 @@ export const getServerSideProps{{#isTypescript}}: GetServerSideProps{{/isTypescr
     apiBasePath: "{{apiBasePath}}",
     prisma,
     schema,
-    options
+    options,
     req,
   });

--- a/packages/cli/src/utils/next.ts
+++ b/packages/cli/src/utils/next.ts
@@ -15,3 +15,29 @@ export const getRouterRoot = (basePath: string) => {
 
   return false;
 };
+
+export const getBabelUsage = (basePath: string) => {
+  const babelConfigPath = globSync(
+    ["babel.config.{js,json}", ".babelrc", ".babelrc.{js,json}"],
+    { cwd: basePath }
+  );
+
+  if (babelConfigPath.length) {
+    return true;
+  }
+
+  return false;
+};
+
+export const getAppFilePath = (basePath: string) => {
+  const appFilePath = globSync(
+    ["src/_app.{js,jsx,ts,tsx}", "_app.{js,jsx,ts,tsx}"],
+    { cwd: basePath }
+  );
+
+  if (appFilePath.length) {
+    return appFilePath[0];
+  }
+
+  return false;
+};

--- a/packages/next-admin/src/pageRouter.ts
+++ b/packages/next-admin/src/pageRouter.ts
@@ -14,6 +14,7 @@ export const getNextAdminProps = async ({
   apiBasePath,
   options,
   req,
+  locale,
 }: Omit<GetNextAdminPropsParams, "params" | "searchParams" | "isAppDir"> & {
   req: IncomingMessage;
 }) => {
@@ -29,6 +30,7 @@ export const getNextAdminProps = async ({
     searchParams: requestOptions,
     params,
     isAppDir: false,
+    locale,
   });
 
   return { props };


### PR DESCRIPTION
## Title

Fixes some issues with page router both with the CLI and the lib

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#452 

## Description

This PR fixes some issues with the Page Router : 
- on the library side, we were not passing the locale prop to `getNextAdminProps`
- on the CLI side, we were generating content with syntax errors and an invalid CSS import. We also needed to add instructions about SuperJson configuration.

