### PR TITLE
fix: add missing package name in install instructions in CLI

### DIFF
--- a/.changeset/early-carpets-notice.md
+++ b/.changeset/early-carpets-notice.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin-cli": patch
+---
+
+fix: add missing package name in install instructions in CLI

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -282,7 +282,7 @@ experimental: {
     }
 
     extraInstructions = `You will need to do the following manually:
-- ${usesBabel ? `${packageManagerData.installDevCmd} babel-plugin-superjson-next superjson@^1` : `${packageManagerData.installDevCmd} next-superjson-plugin superjson`}
+- ${usesBabel ? `${packageManagerData.name} ${packageManagerData.installDevCmd} babel-plugin-superjson-next superjson@^1` : `${packageManagerData.name} ${packageManagerData.installDevCmd} next-superjson-plugin superjson`}
 - ${superjsonInstructions}
 - Add "@premieroctet/next-admin" to your transpilePackages array in the Next.js configuration file 
 `;

--- a/packages/cli/src/utils/next.ts
+++ b/packages/cli/src/utils/next.ts
@@ -31,7 +31,7 @@ export const getBabelUsage = (basePath: string) => {
 
 export const getAppFilePath = (basePath: string) => {
   const appFilePath = globSync(
-    ["src/_app.{js,jsx,ts,tsx}", "_app.{js,jsx,ts,tsx}"],
+    ["src/pages/_app.{js,jsx,ts,tsx}", "pages/_app.{js,jsx,ts,tsx}"],
     { cwd: basePath }
   );
 


### PR DESCRIPTION
## Title

Add missing package name in instructions for Page Router in CLI

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement
