### PR TITLE
fix: crash on undefined relationship length

### DIFF
--- a/.changeset/metal-ties-help.md
+++ b/.changeset/metal-ties-help.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: crash on undefined relationship length (#465)

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -439,8 +439,8 @@ export const findRelationInData = (
        * because one side of a one-to-one relation will not have relationFromFields
        */
       if (
-        (dmmfPropertyRelationFromFields!.length > 0 &&
-          dmmfPropertyRelationToFields!.length > 0) ||
+        (dmmfPropertyRelationFromFields?.length &&
+          dmmfPropertyRelationToFields?.length) ||
         !dmmfProperty.isList
       ) {
         const idProperty = getModelIdProperty(dmmfProperty.type as ModelName);

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -252,7 +252,7 @@ export const fillRelationInSchema =
         if (fieldKind === "object") {
           const modelNameRelation = fieldType as ModelName;
 
-          if (relationToFields!.length > 0) {
+          if (relationToFields?.length) {
             //Relation One-to-Many, Many side
             const enumeration: Enumeration[] = [];
             schema.definitions[modelName].properties[fieldName] = {


### PR DESCRIPTION
## Title

Fix a crash that was occuring when dmmf's relationship arrays were undefined

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#465 

