### PR TITLE
fix: display correctly boolean value in list

### DIFF
--- a/.changeset/dull-cows-thank.md
+++ b/.changeset/dull-cows-thank.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: default boolean display (#466)

--- a/packages/next-admin/src/components/Cell.tsx
+++ b/packages/next-admin/src/components/Cell.tsx
@@ -83,7 +83,7 @@ export default function Cell({ cell, formatter, copyable }: Props) {
               "bg-nextadmin-background-subtle dark:bg-dark-nextadmin-background-subtle text-nextadmin-brand-subtle dark:text-dark-nextadmin-content-subtle"
             )}
           >
-            <p>{cellValue}</p>
+            <p>{cellValue?.toString()}</p>
           </div>
         );
       }


### PR DESCRIPTION
## Title

Correctly display boolean values in list when no formatter is provided

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#466 

