### PR TITLE
feat: add depth selection for actions

### DIFF
--- a/.changeset/dry-tips-thank.md
+++ b/.changeset/dry-tips-thank.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+feat: add depth selection for actions (#443)

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -652,6 +652,12 @@ The `actions` property is an array of objects that allows you to define a set of
       description:
         "a message that will be displayed when the action fails if action doesn't return a message object or throw an error with a message",
     },
+    {
+      name: "depth",
+      type: "Number",
+      description:
+        "a number that defines the depth of the relations to select in the resource. Use this with caution, a number too high can potentially cause slower queries. Defaults to 2.",
+    },
   ]}
 />
 

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -189,6 +189,7 @@ export const options: NextAdminOptions = {
           id: "user-details",
           title: "actions.user.details.title",
           component: <UserDetailsDialog />,
+          depth: 3,
         },
       ],
     },

--- a/packages/next-admin/src/appHandler.ts
+++ b/packages/next-admin/src/appHandler.ts
@@ -58,11 +58,25 @@ export const createHandler = <P extends string = "nextadmin">({
         ?.split(",")
         .map((id) => formatId(resource, id));
 
+      const depth = req.nextUrl.searchParams.get("depth");
+
       if (!ids) {
         return NextResponse.json({ error: "No ids provided" }, { status: 400 });
       }
 
-      const data = await getRawData({ prisma, resource, resourceIds: ids });
+      if (depth && isNaN(Number(depth))) {
+        return NextResponse.json(
+          { error: "Depth should be a number" },
+          { status: 400 }
+        );
+      }
+
+      const data = await getRawData({
+        prisma,
+        resource,
+        resourceIds: ids,
+        maxDepth: depth ? Number(depth) : undefined,
+      });
 
       return NextResponse.json(data);
     })

--- a/packages/next-admin/src/components/ClientActionDialog.tsx
+++ b/packages/next-admin/src/components/ClientActionDialog.tsx
@@ -42,9 +42,16 @@ const ClientActionDialog = <M extends ModelName>({
 
   useEffect(() => {
     setIsLoading(true);
-    fetch(
-      `${apiBasePath}/${slugify(resource)}/raw?ids=${resourceIds.join(",")}`
-    )
+    const params = new URLSearchParams();
+
+    params.set("ids", resourceIds.join(","));
+
+    if (action.depth) {
+      // Avoid negative depth
+      params.set("depth", Math.max(1, action.depth).toString());
+    }
+
+    fetch(`${apiBasePath}/${slugify(resource)}/raw?${params.toString()}`)
       .then((res) => res.json())
       .then(setData)
       .finally(() => {

--- a/packages/next-admin/src/pageHandler.ts
+++ b/packages/next-admin/src/pageHandler.ts
@@ -90,7 +90,18 @@ export const createHandler = <P extends string = "nextadmin">({
         ids = ids?.split(",").map((id: string) => formatId(resource, id));
       }
 
-      const data = await getRawData({ prisma, resource, resourceIds: ids });
+      const depth = req.query.depth;
+
+      if (depth && isNaN(Number(depth))) {
+        return res.status(400).json({ error: "Depth should be a number" });
+      }
+
+      const data = await getRawData({
+        prisma,
+        resource,
+        resourceIds: ids,
+        maxDepth: depth ? Number(depth) : undefined,
+      });
 
       return res.json(data);
     })

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -549,6 +549,12 @@ export type BareModelAction<M extends ModelName> = {
   canExecute?: (item: Model<M>) => boolean;
   icon?: keyof typeof OutlineIcons;
   style?: ActionStyle;
+  /**
+   * Max depth of the related records to select
+   *
+   * @default 2
+   */
+  depth?: number;
 };
 
 export type ServerAction = {

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -50,10 +50,14 @@ export const getEnableToExecuteActions = async <M extends ModelName>(
   actions?: Omit<ModelAction<M>, "action">[]
 ): Promise<OutputModelAction | undefined> => {
   if (actions?.some((action) => action.canExecute)) {
+    const maxDepth = Math.max(0, ...actions.map((action) => action.depth ?? 0));
+
     const data: Model<typeof resource>[] = await getRawData<typeof resource>({
       prisma,
       resource,
       resourceIds: ids,
+      // Apply the default value if its 0
+      maxDepth: maxDepth || undefined,
     });
 
     return actions?.reduce(


### PR DESCRIPTION
## Title

Add depth selection for raw data actions

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#443 

## Description

Add the possibility to select a depth for raw data query for actions. This should be use with caution since a number too high could potentially cause slower queries.

