### PR TITLE
chore: add note about hydration warning for next-themes

### DIFF
--- a/.changeset/thin-flowers-prove.md
+++ b/.changeset/thin-flowers-prove.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin-cli": patch
+---
+
+chore: add extra instructions for app router

--- a/apps/docs/pages/docs/getting-started.mdx
+++ b/apps/docs/pages/docs/getting-started.mdx
@@ -109,7 +109,7 @@ Next-Admin uses a dynamic route `[[...nextadmin]]` to handle all the admin route
     export default async function AdminPage({
       params,
       searchParams,
-    }: PageProps) {
+    }: PageProps) { // or PromisePageProps for Next 15+
       const props = await getNextAdminProps({
         params: params.nextadmin,
         searchParams,
@@ -133,6 +133,12 @@ Next-Admin uses a dynamic route `[[...nextadmin]]` to handle all the admin route
 
     <Callout emoji="⚠️">
       Make sure to not use `use client` in the page.
+    </Callout>
+
+    <Callout emoji="⚠️">
+      Because we are using [next-themes](https://github.com/pacocoursey/next-themes) to handle dark mode,
+      you will need to add the `suppressHydrationWarning` to your the closest `<html>` tag of the admin page.
+      See [the next-themes docs](https://github.com/pacocoursey/next-themes?tab=readme-ov-file#with-app)
     </Callout>
 
   </Tabs.Tab>

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -277,7 +277,13 @@ experimental: {
     extraInstructions = `You will need to do the following manually:
 - ${usesBabel ? `${packageManagerData.name} ${packageManagerData.installDevCmd} babel-plugin-superjson-next superjson@^1` : `${packageManagerData.name} ${packageManagerData.installDevCmd} next-superjson-plugin superjson`}
 - ${superjsonInstructions}
-- Add "@premieroctet/next-admin" to your transpilePackages array in the Next.js configuration file 
+- Add "@premieroctet/next-admin" to your transpilePackages array in the Next.js configuration file
+`;
+  }
+
+  if (routerRootPath.type === "app") {
+    extraInstructions = `You will need to do the following manually:
+- Add the suppressHydrationWarning prop to the closest <html> tag for the admin page
 `;
   }
 


### PR DESCRIPTION
## Title

Add a note in the doc and in the CLI for the suppressHydrationWarning prop

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [x] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#492 

## Description

This relates to a hydration error that occurs with React 19 and Next 15 where next-themes would cause a hydration error. Per [the documentation](https://github.com/pacocoursey/next-themes?tab=readme-ov-file#with-app) we need to add the `suppressHydrationWarning` prop in the closest root layout to make this disappear.
