### PR TITLE
fix: move generated json schema

### DIFF
--- a/.changeset/soft-wasps-kneel.md
+++ b/.changeset/soft-wasps-kneel.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin-generator-prisma": patch
+---
+
+fix: move generated json schema path (#504)

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "database": "prisma migrate dev && prisma db seed",
     "generate": "prisma generate",
+    "generate:client-only": "prisma generate --generator client",
     "reset-database": "prisma migrate reset --force && prisma migrate dev && prisma db seed",
     "prisma:migrate:dev": "prisma migrate dev",
     "vercel-build": "prisma generate && prisma migrate deploy && next build",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:example": "turbo run build --filter=example",
     "build:next-admin": "turbo run build --filter=@premieroctet/next-admin",
     "build:packages": "turbo run build --filter=@premieroctet/next-admin --filter=@premieroctet/next-admin-cli --filter=@premieroctet/next-admin-generator-prisma --filter=@premieroctet/next-admin-json-schema",
-    "setup:packages": "turbo run build --filter=@premieroctet/next-admin-cli --filter=@premieroctet/next-admin-generator-prisma --filter=@premieroctet/next-admin-json-schema && pnpm --filter example exec -- prisma generate && pnpm build:next-admin",
+    "setup:packages": "turbo run build --filter=@premieroctet/next-admin-cli --filter=@premieroctet/next-admin-generator-prisma --filter=@premieroctet/next-admin-json-schema && pnpm build:next-admin",
     "dev": "turbo run dev",
     "dev:docs": "turbo run dev --filter=docs",
     "lint": "turbo run lint",

--- a/packages/generator-prisma/src/index.ts
+++ b/packages/generator-prisma/src/index.ts
@@ -3,21 +3,18 @@ import { generatorHandler } from "@prisma/generator-helper";
 import { parseEnvValue } from "@prisma/internals";
 import path from "path";
 import fs from "fs/promises";
+import { execSync } from "node:child_process";
 // @ts-expect-error
 import { transformDMMF } from "prisma-json-schema-generator/dist/generator/transformDMMF";
 import { insertDmmfData } from "./dmmf";
 
 generatorHandler({
   onManifest: () => {
+    const nodeModulesRoot = execSync("npm root").toString("utf8");
+
     return {
       defaultOutput: path.resolve(
-        path.join(
-          require.resolve("@premieroctet/next-admin"),
-          "..",
-          "..",
-          "node_modules",
-          ".next-admin"
-        )
+        path.join(nodeModulesRoot.trim(), ".next-admin")
       ),
       prettyName: "Next Admin JSON Schema Generator",
     };

--- a/packages/generator-prisma/src/index.ts
+++ b/packages/generator-prisma/src/index.ts
@@ -3,18 +3,21 @@ import { generatorHandler } from "@prisma/generator-helper";
 import { parseEnvValue } from "@prisma/internals";
 import path from "path";
 import fs from "fs/promises";
-import { execSync } from "node:child_process";
 // @ts-expect-error
 import { transformDMMF } from "prisma-json-schema-generator/dist/generator/transformDMMF";
 import { insertDmmfData } from "./dmmf";
 
 generatorHandler({
   onManifest: () => {
-    const nodeModulesRoot = execSync("npm root").toString("utf8");
-
     return {
       defaultOutput: path.resolve(
-        path.join(nodeModulesRoot.trim(), ".next-admin")
+        path.join(
+          require.resolve("@premieroctet/next-admin"),
+          "..",
+          "..",
+          "node_modules",
+          ".next-admin"
+        )
       ),
       prettyName: "Next Admin JSON Schema Generator",
     };

--- a/packages/generator-prisma/src/index.ts
+++ b/packages/generator-prisma/src/index.ts
@@ -8,20 +8,20 @@ import { transformDMMF } from "prisma-json-schema-generator/dist/generator/trans
 import { insertDmmfData } from "./dmmf";
 
 generatorHandler({
-  onManifest: () => ({
-    defaultOutput: path.resolve(
-      path.join(
-        require.resolve("@premieroctet/next-admin-generator-prisma"),
-        "..",
-        "..",
-        "..",
-        "..",
-        "node_modules",
-        ".next-admin"
-      )
-    ),
-    prettyName: "Next Admin JSON Schema Generator",
-  }),
+  onManifest: () => {
+    return {
+      defaultOutput: path.resolve(
+        path.join(
+          require.resolve("@premieroctet/next-admin"),
+          "..",
+          "..",
+          "node_modules",
+          ".next-admin"
+        )
+      ),
+      prettyName: "Next Admin JSON Schema Generator",
+    };
+  },
   onGenerate: async (options) => {
     const jsonSchema = transformDMMF(options.dmmf, {
       ...options.generator.config,

--- a/turbo.json
+++ b/turbo.json
@@ -11,9 +11,9 @@
   "tasks": {
     "start": {},
     "@premieroctet/next-admin#build": {
-      "dependsOn": ["example#generate"]
+      "dependsOn": ["example#generate:client-only"]
     },
-    "example#generate": {
+    "example#generate:client-only": {
       "dependsOn": ["@premieroctet/next-admin-generator-prisma#build"]
     },
     "build": {


### PR DESCRIPTION
## Title

Update path of the generated JSON Schema

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#504 

## Description

This is an attempt to fix an issue that arised with PNPM, because of the way PNPM installs the packages, the .next-admin folder which contains the JSON schema was generated in a place that could not be resolved by Node.
This fix generates the schema in the node_modules of the `next-admin` package, which should make it accessible.
