### PR TITLE
fix: remove anyOf for one-to-many relations

### DIFF
--- a/.changeset/clean-dolphins-report.md
+++ b/.changeset/clean-dolphins-report.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin-generator-prisma": patch
+---
+
+fix: remove anyOf for one-to-many relations (#513)

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -341,9 +341,19 @@ export const options: NextAdminOptions = {
       icon: "UserIcon",
       list: {
         display: ["id", "user"],
+        fields: {
+          user: {
+            formatter: (user) => user.email,
+          },
+        },
       },
       edit: {
         display: ["user", "bio"],
+        fields: {
+          user: {
+            optionFormatter: (user) => user.email,
+          },
+        },
       },
     },
   },

--- a/packages/generator-prisma/src/dmmf.ts
+++ b/packages/generator-prisma/src/dmmf.ts
@@ -128,6 +128,13 @@ export const insertDmmfData = (
             relation: getRelationData(dmmf, dmmfField, dmmfModel.name),
           }
         );
+
+        if (
+          dmmfField.kind === "object" &&
+          (model.properties![propertyName] as NextAdminJSONSchema)?.anyOf
+        ) {
+          delete (model.properties![propertyName] as NextAdminJSONSchema).anyOf;
+        }
       }
     });
   });


### PR DESCRIPTION
## Title

Fix display of one-to-many fields in create and edit form

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#513 

