### PR TITLE
feat: add edit and delete middlewares

### DIFF
--- a/.changeset/long-bobcats-cough.md
+++ b/.changeset/long-bobcats-cough.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+feat: add edit and delete middlewares (#527 #528)

--- a/packages/next-admin/src/appHandler.ts
+++ b/packages/next-admin/src/appHandler.ts
@@ -222,10 +222,7 @@ export const createHandler = <P extends string = "nextadmin">({
         });
 
         if (!deleted) {
-          return NextResponse.json(
-            { error: "Deletion failed" },
-            { status: 500 }
-          );
+          throw new Error('Deletion failed')
         }
 
         return NextResponse.json({ ok: true });

--- a/packages/next-admin/src/appHandler.ts
+++ b/packages/next-admin/src/appHandler.ts
@@ -213,13 +213,28 @@ export const createHandler = <P extends string = "nextadmin">({
         );
       }
 
-      await deleteResource({
-        body: [params[paramKey][1]],
-        prisma,
-        resource,
-      });
+      try {
+        const deleted = await deleteResource({
+          body: [params[paramKey][1]],
+          prisma,
+          resource,
+          modelOptions: options?.model?.[resource],
+        });
 
-      return NextResponse.json({ ok: true });
+        if (!deleted) {
+          return NextResponse.json(
+            { error: "Deletion failed" },
+            { status: 500 }
+          );
+        }
+
+        return NextResponse.json({ ok: true });
+      } catch (e) {
+        return NextResponse.json(
+          { error: (e as Error).message },
+          { status: 500 }
+        );
+      }
     })
     .delete(`${apiBasePath}/:model`, async (req, ctx) => {
       const params = await ctx.params;
@@ -241,7 +256,12 @@ export const createHandler = <P extends string = "nextadmin">({
       try {
         const body = await req.json();
 
-        await deleteResource({ body, prisma, resource });
+        await deleteResource({
+          body,
+          prisma,
+          resource,
+          modelOptions: options?.model?.[resource],
+        });
 
         return NextResponse.json({ ok: true });
       } catch (e) {

--- a/packages/next-admin/src/components/Form.tsx
+++ b/packages/next-admin/src/components/Form.tsx
@@ -112,7 +112,7 @@ const Form = ({
   const formRef = useRef<RjsfForm>(null);
   const [isPending, setIsPending] = useState(false);
   const allDisabled = edit && !canEdit;
-  const { runDeletion } = useDeleteAction(resource);
+  const { runSingleDeletion } = useDeleteAction(resource);
   const { showMessage } = useMessage();
   const { cleanAll } = useFormState();
   const { setFormData } = useFormData();
@@ -173,7 +173,7 @@ const Form = ({
                   } else {
                     try {
                       setIsPending(true);
-                      await runDeletion([id!] as string[] | number[]);
+                      await runSingleDeletion(id!);
                       router.replace({
                         pathname: `${basePath}/${slugify(resource)}`,
                         query: {

--- a/packages/next-admin/src/handlers/resources.ts
+++ b/packages/next-admin/src/handlers/resources.ts
@@ -40,7 +40,6 @@ export const deleteResource = async ({
 }: DeleteResourceParams) => {
   const modelIdProperty = getModelIdProperty(resource);
 
-  console.log("modelOptions middlewares", modelOptions?.middlewares);
 
   if (modelOptions?.middlewares?.delete) {
     // @ts-expect-error

--- a/packages/next-admin/src/hooks/useDeleteAction.ts
+++ b/packages/next-admin/src/hooks/useDeleteAction.ts
@@ -26,6 +26,17 @@ export const useDeleteAction = (resource: ModelName) => {
     }
   };
 
+  const runSingleDeletion = async (id: string | number) => {
+    const response = await fetch(`${apiBasePath}/${slugify(resource)}/${id}`, {
+      method: "DELETE",
+    });
+
+    if (!response.ok) {
+      const result = await response.json();
+      throw new Error(result.error);
+    }
+  };
+
   const deleteItems = async (ids: string[] | number[]) => {
     if (
       window.confirm(t("list.row.actions.delete.alert", { count: ids.length }))
@@ -46,5 +57,5 @@ export const useDeleteAction = (resource: ModelName) => {
     }
   };
 
-  return { deleteItems, runDeletion };
+  return { deleteItems, runDeletion, runSingleDeletion };
 };

--- a/packages/next-admin/src/pageHandler.ts
+++ b/packages/next-admin/src/pageHandler.ts
@@ -245,7 +245,7 @@ export const createHandler = <P extends string = "nextadmin">({
         });
 
         if (!deleted) {
-          return res.status(500).json({ error: "Deletion failed" });
+          throw new Error("Deletion failed")
         }
 
         return res.json({ ok: true });

--- a/packages/next-admin/src/pageHandler.ts
+++ b/packages/next-admin/src/pageHandler.ts
@@ -237,11 +237,16 @@ export const createHandler = <P extends string = "nextadmin">({
       }
 
       try {
-        await deleteResource({
+        const deleted = await deleteResource({
           body: [req.query[paramKey]![1]],
           prisma,
           resource,
+          modelOptions: options?.model?.[resource],
         });
+
+        if (!deleted) {
+          return res.status(500).json({ error: "Deletion failed" });
+        }
 
         return res.json({ ok: true });
       } catch (e) {
@@ -273,7 +278,12 @@ export const createHandler = <P extends string = "nextadmin">({
       }
 
       try {
-        await deleteResource({ body, prisma, resource });
+        await deleteResource({
+          body,
+          prisma,
+          resource,
+          modelOptions: options?.model?.[resource],
+        });
 
         return res.json({ ok: true });
       } catch (e) {

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -344,6 +344,12 @@ export type Handler<
    * an optional string displayed in the input field as an error message in case of a failure during the upload handler.
    */
   uploadErrorMessage?: string;
+  /**
+   * an async function that takes the resource value as parameter and returns a boolean. If false is returned, the deletion will not happen.
+   * @param input
+   * @returns boolean
+   */
+  delete?: (input: T) => Promise<boolean> | boolean;
 };
 
 export type UploadParameters = Parameters<
@@ -613,6 +619,25 @@ export enum Permission {
 
 export type PermissionType = "create" | "edit" | "delete";
 
+export type ModelMiddleware<T extends ModelName> = {
+  /**
+   * a function that is called before the form data is sent to the database.
+   * @param data - the form data as a record
+   * @param currentData - the current data in the database
+   * @returns boolean - if false is returned, the update will not happen.
+   */
+  edit?: (
+    updatedData: Model<T>,
+    currentData: Model<T>
+  ) => Promise<boolean> | boolean;
+  /**
+   * a function that is called before resource is deleted from the database.
+   * @param data - the current data in the database
+   * @returns boolean - if false is returned, the deletion will not happen.
+   */
+  delete?: (data: Model<T>) => Promise<boolean> | boolean;
+};
+
 export type ModelOptions<T extends ModelName> = {
   [P in T]?: {
     /**
@@ -644,6 +669,7 @@ export type ModelOptions<T extends ModelName> = {
      */
     icon?: ModelIcon;
     permissions?: PermissionType[];
+    middlewares?: ModelMiddleware<P>;
   };
 };
 


### PR DESCRIPTION
## Title

Add edit and delete middlewares

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#527 #528

## Description

To give more granularity to the edition and deletion, we now provide a way to do stuff just before Prisma executes the update / delete queries. This gives the ability to interact with a remote CDN for example, where resource associated files can be accordingly added / removed.
