### PR TITLE
feat: add max items for scalar arrays

### DIFF
--- a/.changeset/modern-kids-wonder.md
+++ b/.changeset/modern-kids-wonder.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+feat: add max items for scalar arrays

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -580,6 +580,11 @@ When you define a field, use the field's name as the key and the following objec
           It accepts a property <code>perPage</code> defining the amount of items per page (defaults to 20)
         </>
       )
+    },
+    {
+      name: "maxLength",
+      type: "Number",
+      description: "a number that defines the maximum number of items a scalar array can contain."
     }
   ]}
 />

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -110,8 +110,7 @@ export const options: NextAdminOptions = {
             input: <DatePicker />,
           },
           posts: {
-            display: "list",
-            orderField: "order",
+            display: "table",
           },
           avatar: {
             format: "file",
@@ -301,6 +300,7 @@ export const options: NextAdminOptions = {
                 return faker.image.url({ width: 200, height: 200 });
               },
             },
+            maxLength: 5,
           },
         },
         display: [

--- a/packages/next-admin/src/components/inputs/FileWidget/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget/FileWidget.tsx
@@ -44,7 +44,13 @@ const FileWidget = (props: Props) => {
           return [selectedFiles[0]];
         }
 
-        return [...old, ...Array.from(selectedFiles)];
+        const newArray = [...old, ...Array.from(selectedFiles)];
+
+        if (props.schema?.maxItems) {
+          return newArray.slice(0, props.schema.maxItems);
+        }
+
+        return newArray;
       });
     }
   };
@@ -82,7 +88,13 @@ const FileWidget = (props: Props) => {
       setFieldDirty(props.name);
       setFiles((old) => {
         if (acceptsMultipleFiles) {
-          return [...old, ...Array.from(event.dataTransfer.files)];
+          const newArray = [...old, ...Array.from(event.dataTransfer.files)];
+
+          if (props.schema?.maxItems) {
+            return newArray.slice(0, props.schema.maxItems);
+          }
+
+          return newArray;
         }
 
         return [event.dataTransfer.files[0]];

--- a/packages/next-admin/src/components/inputs/ScalarArray/ScalarArrayField.tsx
+++ b/packages/next-admin/src/components/inputs/ScalarArray/ScalarArrayField.tsx
@@ -86,13 +86,19 @@ const ScalarArrayField = ({
   };
 
   const onAddNewItem = () => {
-    setFormDataList((prev) => [
-      ...prev,
-      {
-        id: crypto.randomUUID(),
-        value: "",
-      },
-    ]);
+    setFormDataList((prev) => {
+      if (schema.maxItems && prev.length >= schema.maxItems) {
+        return prev;
+      }
+
+      return [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          value: "",
+        },
+      ];
+    });
     setFieldDirty(name);
   };
 
@@ -115,7 +121,10 @@ const ScalarArrayField = ({
       <Button
         type="button"
         className="w-fit"
-        disabled={disabled}
+        disabled={
+          disabled ||
+          (schema.maxItems ? formDataList.length >= schema.maxItems : false)
+        }
         onClick={onAddNewItem}
       >
         {t("form.widgets.scalar_array.add")}

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -248,6 +248,8 @@ export type RelationshipPagination = {
   perPage?: number;
 };
 
+export type ScalarArray = string[] | number[] | boolean[];
+
 export type EditFieldsOptions<T extends ModelName> = {
   [P in Field<T>]?: {
     /**
@@ -288,6 +290,7 @@ export type EditFieldsOptions<T extends ModelName> = {
      * a function that takes the field value as parameter and returns a boolean to determine if the field is displayed in the form.
      */
     visible?: (value: ModelWithoutRelationships<T>) => boolean;
+    maxLength?: Model<T>[P] extends ScalarArray ? number : never;
   } & (P extends keyof ObjectField<T>
     ? OptionFormatterFromRelationshipSearch<T, P> &
         (

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -1168,7 +1168,8 @@ export const transformSchema = <M extends ModelName>(
     fillRelationInSchema(resource, options),
     fillDescriptionInSchema(resource, edit),
     addCustomProperties(resource, edit),
-    orderSchema(resource, options)
+    orderSchema(resource, options),
+    applyArrayMaxLength(resource, edit)
   );
 
 export const applyVisiblePropertiesInSchema = <M extends ModelName>(
@@ -1294,6 +1295,24 @@ export const addCustomProperties =
       }
     });
 
+    return schema;
+  };
+
+export const applyArrayMaxLength =
+  <M extends ModelName>(resource: M, editOptions: EditOptions<M>) =>
+  (schema: Schema) => {
+    const modelName = resource;
+    const modelSchema = schema.definitions[
+      modelName
+    ] as SchemaDefinitions[ModelName];
+    if (!modelSchema) return schema;
+    Object.entries(modelSchema.properties).forEach(([name]) => {
+      const propertyName = name as Field<typeof modelName>;
+      const fieldValue = schema.definitions[modelName].properties[propertyName];
+      if (fieldValue && editOptions?.fields?.[propertyName]?.maxLength) {
+        fieldValue.maxItems = editOptions?.fields?.[propertyName]?.maxLength;
+      }
+    });
     return schema;
   };
 


### PR DESCRIPTION
## Title

Add max items scalar arrays

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This adds the possibility to define the maximum items a scalar array can contain, with the `maxLength` property on an edit field.
