### PR TITLE
feat: allow pagination for relationship display

### DIFF
--- a/.changeset/old-turkeys-speak.md
+++ b/.changeset/old-turkeys-speak.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+feat: allow pagination for relationship display

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -571,6 +571,16 @@ When you define a field, use the field's name as the key and the following objec
       description:
         "a function that takes the resource value as a parameter, and returns a boolean that shows or hides the field in the edit form",
     },
+    {
+      name: "pagination",
+      type: "object",
+      description: (
+        <>
+          An object (can be empty) that adds pagination for multi select fields (with <code>display</code> set to either <code>table</code> or <code>list</code>).
+          It accepts a property <code>perPage</code> defining the amount of items per page (defaults to 20)
+        </>
+      )
+    }
   ]}
 />
 
@@ -695,13 +705,15 @@ The `middlewares` property is an object of functions executed either before a re
     {
       name: "edit",
       type: "Function",
-      description: "a function that is called before the form data is sent to the database. It takes the submitted form data as its first argument, and the current value in the database as its second argument. If false is returned, the update will not happen."
+      description:
+        "a function that is called before the form data is sent to the database. It takes the submitted form data as its first argument, and the current value in the database as its second argument. If false is returned, the update will not happen.",
     },
     {
       name: "delete",
       type: "Function",
-      description: "a function that is called before the record is deleted. It takes the record to delete as its only argument. If false is returned, the deletion will not happen."
-    }
+      description:
+        "a function that is called before the record is deleted. It takes the record to delete as its only argument. If false is returned, the deletion will not happen.",
+    },
   ]}
 />
 

--- a/packages/next-admin/src/components/Pagination.tsx
+++ b/packages/next-admin/src/components/Pagination.tsx
@@ -7,8 +7,8 @@ const MAX_SHOWN_PAGES = 5;
   @param {number} currentPageIndex - current index of the page
   @param {string} separator - separator between pages
   @param {number} maxShownPages - maximum number of pages to display
-  @returns {[number | string]} - array of pages to display 
-  @example [1, 2, 3, '...', 10] 
+  @returns {[number | string]} - array of pages to display
+  @example [1, 2, 3, '...', 10]
   @example [1, 2, 3, 4]
 */
 function getShownPagesPagination(
@@ -79,6 +79,7 @@ export function Pagination({
         aria-label="Pagination"
       >
         <button
+          type="button"
           disabled={!getCanPreviousPage()}
           onClick={() => {
             onPageChange(currentPageIndex - 1);
@@ -96,6 +97,7 @@ export function Pagination({
         ).map((pageNumber, index) => (
           <button
             key={index}
+            type="button"
             aria-current="page"
             onClick={() => {
               if (isNaN(Number(pageNumber))) return;
@@ -104,7 +106,7 @@ export function Pagination({
             className={
               pageNumber === currentPageIndex + 1
                 ? "bg-nextadmin-brand-default dark:bg-dark-nextadmin-background-muted ring-nextadmin-border-strong dark:ring-dark-nextadmin-border-strong/50 text-nextadmin-brand-inverted dark:text-dark-nextadmin-brand-inverted relative z-10 inline-flex items-center px-4 py-2 text-sm font-semibold focus:z-20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 dark:ring-1 dark:ring-inset"
-                : "ring-nextadmin-border-strong dark:ring-dark-nextadmin-border-strong/5 relative hidden items-center px-4 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset hover:bg-gray-50 focus:z-20 focus:outline-offset-0 dark:text-white dark:hover:bg-slate-500 md:inline-flex"
+                : "ring-nextadmin-border-strong dark:ring-dark-nextadmin-border-strong/5 relative hidden items-center px-4 py-2 text-sm font-semibold text-gray-900 ring-1 ring-inset hover:bg-gray-50 focus:z-20 focus:outline-offset-0 md:inline-flex dark:text-white dark:hover:bg-slate-500"
             }
           >
             {pageNumber}
@@ -112,6 +114,7 @@ export function Pagination({
         ))}
         <button
           disabled={!getCanNextPage()}
+          type="button"
           onClick={() => {
             onPageChange(currentPageIndex + 1);
           }}

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayList.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayList.tsx
@@ -1,8 +1,12 @@
 import { DndContext, DragEndEvent } from "@dnd-kit/core";
 import { SortableContext } from "@dnd-kit/sortable";
 import { RJSFSchema } from "@rjsf/utils";
-import { Enumeration } from "../../../types";
+import { Enumeration, RelationshipPagination } from "../../../types";
 import MultiSelectDisplayListItem from "./MultiSelectDisplayListItem";
+import { useMemo, useState } from "react";
+import useLocalPagination from "../../../hooks/useLocalPagination";
+import { Pagination } from "../../Pagination";
+import { end } from "slate";
 
 type Props = {
   formData: any;
@@ -11,6 +15,7 @@ type Props = {
   deletable: boolean;
   sortable?: boolean;
   onUpdateFormData?: (value: Enumeration[]) => void;
+  pagination?: RelationshipPagination;
 };
 
 const MultiSelectDisplayList = ({
@@ -20,7 +25,14 @@ const MultiSelectDisplayList = ({
   deletable = true,
   sortable = false,
   onUpdateFormData,
+  pagination,
 }: Props) => {
+  const { dataToRender, handlePageChange, totalPages, pageIndex } =
+    useLocalPagination<Enumeration>(
+      formData,
+      pagination ? (pagination.perPage ?? 20) : undefined
+    );
+
   const onDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
 
@@ -39,20 +51,31 @@ const MultiSelectDisplayList = ({
 
   const renderList = () => {
     return (
-      <ul className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted space-y-2">
-        {formData?.map((value: Enumeration) => {
-          return (
-            <MultiSelectDisplayListItem
-              item={value}
-              key={value.value}
-              onRemoveClick={onRemoveClick}
-              deletable={deletable}
-              sortable={sortable}
-              schema={schema}
+      <div className="flex flex-col gap-2">
+        <ul className="text-nextadmin-content-inverted dark:text-dark-nextadmin-content-inverted space-y-2">
+          {dataToRender?.map((value: Enumeration) => {
+            return (
+              <MultiSelectDisplayListItem
+                item={value}
+                key={value.value}
+                onRemoveClick={onRemoveClick}
+                deletable={deletable}
+                sortable={sortable}
+                schema={schema}
+              />
+            );
+          })}
+        </ul>
+        {!!pagination && (
+          <div className="self-end">
+            <Pagination
+              currentPageIndex={pageIndex}
+              totalPageCount={totalPages}
+              onPageChange={handlePageChange}
             />
-          );
-        })}
-      </ul>
+          </div>
+        )}
+      </div>
     );
   };
 

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayTable.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayTable.tsx
@@ -1,14 +1,17 @@
 import { RJSFSchema } from "@rjsf/utils";
 import { useConfig } from "../../../context/ConfigContext";
 import useDataColumns from "../../../hooks/useDataColumns";
-import { Enumeration } from "../../../types";
+import { Enumeration, RelationshipPagination } from "../../../types";
 import { DataTable } from "../../DataTable";
+import useLocalPagination from "../../../hooks/useLocalPagination";
+import { Pagination } from "../../Pagination";
 
 type Props = {
   formData: Enumeration[];
   schema: RJSFSchema;
   onRemoveClick: (value: any) => void;
   deletable: boolean;
+  pagination?: RelationshipPagination;
 };
 
 const MultiSelectDisplayTable = ({
@@ -16,10 +19,17 @@ const MultiSelectDisplayTable = ({
   schema,
   deletable,
   onRemoveClick,
+  pagination,
 }: Props) => {
   const { resourcesIdProperty } = useConfig();
+  const { dataToRender, handlePageChange, totalPages, pageIndex } =
+    useLocalPagination<Enumeration>(
+      formData,
+      pagination ? (pagination.perPage ?? 20) : undefined
+    );
+
   const columns = useDataColumns({
-    data: formData?.map((data) => data.data),
+    data: dataToRender?.map((data) => data.data),
     sortable: false,
     resourcesIdProperty: resourcesIdProperty!,
     // @ts-expect-error
@@ -28,16 +38,27 @@ const MultiSelectDisplayTable = ({
 
   return (
     formData?.map((data) => data.data).length > 0 && (
-      <DataTable
-        columns={columns}
-        data={formData?.map((data) => data.data)}
-        // @ts-expect-error
-        resource={schema.items?.relation}
-        resourcesIdProperty={resourcesIdProperty!}
-        rowSelection={{}}
-        deletable={deletable}
-        onRemoveClick={onRemoveClick}
-      />
+      <div className="flex flex-col gap-2">
+        <DataTable
+          columns={columns}
+          data={dataToRender?.map((data) => data.data)}
+          // @ts-expect-error
+          resource={schema.items?.relation}
+          resourcesIdProperty={resourcesIdProperty!}
+          rowSelection={{}}
+          deletable={deletable}
+          onRemoveClick={onRemoveClick}
+        />
+        {!!pagination && (
+          <div className="self-end">
+            <Pagination
+              currentPageIndex={pageIndex}
+              totalPageCount={totalPages}
+              onPageChange={handlePageChange}
+            />
+          </div>
+        )}
+      </div>
     )
   );
 };

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectWidget.tsx
@@ -6,7 +6,12 @@ import { useFormState } from "../../../context/FormStateContext";
 import { useI18n } from "../../../context/I18nContext";
 import useClickOutside from "../../../hooks/useCloseOnOutsideClick";
 import { useDisclosure } from "../../../hooks/useDisclosure";
-import { Enumeration, Field, ModelName } from "../../../types";
+import {
+  Enumeration,
+  Field,
+  ModelName,
+  RelationshipPagination,
+} from "../../../types";
 import Button from "../../radix/Button";
 import { Selector } from "../Selector";
 import MultiSelectDisplayList from "./MultiSelectDisplayList";
@@ -44,6 +49,11 @@ const MultiSelectWidget = (props: Props) => {
     !!fieldOptions && "display" in fieldOptions
       ? (fieldOptions.display ?? "select")
       : "select";
+
+  const fieldPagination =
+    !!fieldOptions && "pagination" in fieldOptions
+      ? (fieldOptions.pagination as RelationshipPagination)
+      : undefined;
 
   const fieldSortable =
     // @ts-expect-error
@@ -117,6 +127,7 @@ const MultiSelectWidget = (props: Props) => {
               setFieldDirty(name);
               onChange(value);
             }}
+            pagination={fieldPagination}
           />
 
           <Button
@@ -137,6 +148,7 @@ const MultiSelectWidget = (props: Props) => {
             schema={schema}
             onRemoveClick={onRemoveClick}
             deletable={!props.disabled}
+            pagination={fieldPagination}
           />
 
           <Button

--- a/packages/next-admin/src/hooks/useLocalPagination.ts
+++ b/packages/next-admin/src/hooks/useLocalPagination.ts
@@ -1,0 +1,40 @@
+import { useMemo, useState } from "react";
+
+const useLocalPagination = <T extends unknown>(
+  data: T[],
+  pageSize?: number
+) => {
+  const [pageIndex, setPageIndex] = useState(0);
+
+  const dataToRender = useMemo(() => {
+    if (!pageSize) {
+      return data;
+    }
+
+    const startIndex = pageIndex * pageSize;
+    const endIndex = startIndex + pageSize;
+    return data.slice(startIndex, endIndex);
+  }, [data, pageIndex, pageSize]);
+
+  const totalPages = useMemo(() => {
+    if (!pageSize) {
+      return 1;
+    }
+    return Math.ceil(data.length / pageSize);
+  }, [data, pageSize]);
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage >= 0 && newPage < totalPages) {
+      setPageIndex(newPage);
+    }
+  };
+
+  return {
+    dataToRender,
+    totalPages,
+    handlePageChange,
+    pageIndex,
+  };
+};
+
+export default useLocalPagination;

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -244,6 +244,10 @@ type OptionFormatterFromRelationshipSearch<
       };
 }[RelationshipSearch<ModelFromProperty<T, P>>["field"]];
 
+export type RelationshipPagination = {
+  perPage?: number;
+};
+
 export type EditFieldsOptions<T extends ModelName> = {
   [P in Field<T>]?: {
     /**
@@ -296,9 +300,17 @@ export type EditFieldsOptions<T extends ModelName> = {
                *
                * @default "select"
                */
-              display?: "table" | "select";
+              display?: "select";
             }
-          | { display?: "list"; orderField?: keyof ModelFromProperty<T, P> }
+          | {
+              display?: "table";
+              pagination?: RelationshipPagination;
+            }
+          | {
+              display?: "list";
+              orderField?: keyof ModelFromProperty<T, P>;
+              pagination?: RelationshipPagination;
+            }
         )
     : P extends keyof ScalarField<T>
       ? ScalarField<T>[P] extends (infer Q)[]
@@ -442,7 +454,7 @@ export type ListOptions<T extends ModelName> = {
     direction?: Prisma.SortOrder;
   };
   /**
-   * An optional field to enable ordering on the list. 
+   * An optional field to enable ordering on the list.
    * ⚠️ When enabled, it will disable all other types of sorting.
    * @restriction Only scalar fields are allowed, and primary keys are not permitted. The field must be a numeric type.
    */


### PR DESCRIPTION
## Title

Allow pagination on relationship fields display on the edit page

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#542 

## Description

Add a new `pagination` property on a relationship edit field. it can be empty or contain `perPage` (defaults to 20).

## Screenshots

![image](https://github.com/user-attachments/assets/f4860b72-9ab1-4bbd-936e-a3ca2dc63cee)

![image](https://github.com/user-attachments/assets/6c4daa42-69fe-4852-a007-cb58b07a38d5)

