### PR TITLE
Disable header sort when orderField is used

### DIFF
--- a/packages/next-admin/src/components/List.tsx
+++ b/packages/next-admin/src/components/List.tsx
@@ -82,7 +82,7 @@ function List({
   const columns = useDataColumns({
     data,
     resource,
-    sortable: true,
+    sortable: modelOptions?.list?.orderField ? false : true,
     resourcesIdProperty,
     sortColumn,
     sortDirection,

--- a/packages/next-admin/src/components/TableHead.tsx
+++ b/packages/next-admin/src/components/TableHead.tsx
@@ -11,6 +11,7 @@ interface Props {
   sortDirection?: "asc" | "desc";
   property: string;
   propertyName: string;
+  className?: string;
 }
 export default function TableHead({
   onClick,
@@ -18,6 +19,7 @@ export default function TableHead({
   sortDirection,
   property,
   propertyName,
+  className,
 }: Props) {
   const [isPending, startTransition] = useTransition();
   const isSorted = sortColumn === property;
@@ -29,7 +31,7 @@ export default function TableHead({
           onClick();
         });
       }}
-      className="inline-flex items-center justify-center text-sm"
+      className={clsx("inline-flex items-center justify-center text-sm", className)}
     >
       <span
         className={clsx(

--- a/packages/next-admin/src/hooks/useDataColumns.tsx
+++ b/packages/next-admin/src/hooks/useDataColumns.tsx
@@ -52,6 +52,7 @@ const useDataColumns = ({
             header: () => {
               return (
                 <TableHead
+                  className={sortable ? "cursor-pointer" : "cursor-default"}
                   sortDirection={sortDirection}
                   sortColumn={sortColumn}
                   property={property}


### PR DESCRIPTION
## Title

Disable header sort when `orderField` property is used

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#362 

