### PR TITLE
feat: add new server side action component

### DIFF
--- a/.changeset/tame-singers-notice.md
+++ b/.changeset/tame-singers-notice.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+feat: add new server side action component (#514)

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -644,7 +644,11 @@ The `actions` property is an array of objects that allows you to define a set of
           <a href="#clientactiondialogcontentprops">
             ClientActionDialogContentProps
           </a>{" "}
-          for the props passed to the component.
+          for the props passed to the component.<br /><br />
+          For a server side action, it is used inside the message shown at the top of the page
+          after the action execution. It receives a prop <code>message</code> containing the
+          message to be displayed. Useful in case you want to display custom content,
+          for example as Markdown.
         </>
       ),
     },

--- a/packages/next-admin/src/components/Message.tsx
+++ b/packages/next-admin/src/components/Message.tsx
@@ -6,7 +6,7 @@ import {
   XCircleIcon,
 } from "@heroicons/react/24/outline";
 import clsx from "clsx";
-import { useEffect } from "react";
+import { cloneElement, useEffect } from "react";
 import { useMessage } from "../context/MessageContext";
 
 export const Message = (props: React.HTMLAttributes<HTMLDivElement>) => {
@@ -46,8 +46,12 @@ export const Message = (props: React.HTMLAttributes<HTMLDivElement>) => {
               <InformationCircleIcon className="h-5 w-5" aria-hidden="true" />
             )}
           </div>
-          <div className="ml-3">
-            <p className="text-sm font-medium">{message.message}</p>
+          <div className="ml-3 text-sm font-medium">
+            {!message.component ? (
+              <p>{message.message}</p>
+            ) : (
+              cloneElement(message.component, { message: message.message })
+            )}
           </div>
         </div>
       </div>

--- a/packages/next-admin/src/context/MessageContext.tsx
+++ b/packages/next-admin/src/context/MessageContext.tsx
@@ -1,7 +1,11 @@
 "use client";
 import { PropsWithChildren, createContext, useContext, useState } from "react";
 import { useRouterInternal } from "../hooks/useRouterInternal";
-import { MessageContextType, MessageData } from "../types";
+import {
+  MessageContextType,
+  MessageData,
+  MessageDataWithCustomComponent,
+} from "../types";
 
 const MessageContext = createContext<MessageContextType>({
   showMessage: () => {},
@@ -11,23 +15,25 @@ const MessageContext = createContext<MessageContextType>({
 
 export const MessageProvider = ({ children }: PropsWithChildren) => {
   const { query } = useRouterInternal();
-  const [message, setMessage] = useState<MessageData | null>(() => {
-    if (query.message) {
-      try {
-        const data = JSON.parse(query.message);
+  const [message, setMessage] = useState<MessageDataWithCustomComponent | null>(
+    () => {
+      if (query.message) {
+        try {
+          const data = JSON.parse(query.message);
 
-        if (data.type && data.message) {
-          return data;
+          if (data.type && data.message) {
+            return data;
+          }
+
+          return null;
+        } catch {
+          return null;
         }
-
-        return null;
-      } catch {
-        return null;
       }
-    }
 
-    return null;
-  });
+      return null;
+    }
+  );
 
   const showMessage = (messageData: MessageData) => {
     setMessage(messageData);

--- a/packages/next-admin/src/hooks/useAction.ts
+++ b/packages/next-admin/src/hooks/useAction.ts
@@ -46,6 +46,7 @@ export const useAction = <M extends ModelName>(
           showMessage({
             type: actionMessage.type,
             message: t(actionMessage.message),
+            component: modelAction.component,
           });
           return;
         }
@@ -59,6 +60,7 @@ export const useAction = <M extends ModelName>(
         showMessage({
           type: "success",
           message: t(modelAction.successMessage),
+          component: modelAction.component,
         });
       }
     } catch {
@@ -66,6 +68,7 @@ export const useAction = <M extends ModelName>(
         showMessage({
           type: "error",
           message: t(modelAction.errorMessage),
+          component: modelAction.component,
         });
       }
     }

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -589,9 +589,17 @@ export type MessageData = {
   message: string;
 };
 
+export type ServerActionCustomComponent = React.ReactElement<{
+  message?: string;
+}>;
+
+export type MessageDataWithCustomComponent = MessageData & {
+  component?: ServerActionCustomComponent;
+};
+
 export type MessageContextType = {
-  showMessage: (message: MessageData) => void;
-  message: MessageData | null;
+  showMessage: (message: MessageDataWithCustomComponent) => void;
+  message: MessageDataWithCustomComponent | null;
   hideMessage: () => void;
 };
 
@@ -614,6 +622,11 @@ export type ServerAction = {
   action: (ids: string[] | number[]) => Promise<void | MessageData>;
   successMessage?: string;
   errorMessage?: string;
+  /**
+   * Component shown inside the Message component. If not passed, the message
+   * string is displayed in a `p` HTML element.
+   */
+  component?: ServerActionCustomComponent;
 } & BareModelAction<ModelName>;
 
 export type ClientAction<T extends ModelName> = {

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -646,7 +646,7 @@ export type UnionModelAction = {
 
 export type OutputModelAction = (Omit<
   UnionModelAction,
-  "action" | "canExecute"
+  "action" | "canExecute" | "component"
 > & {
   allowedIds?: string[] | number[];
 })[];


### PR DESCRIPTION
## Title

Allow passing custom component for server side actions

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#514 

## Description

Allow passing custom component (must be client) for server side actions that will be used inside the `Message` component displayed atfer the action's execution, instead of a simple `p` HTML tag containing the message.

