### PR TITLE
fix: absolute url for virtual fields

### DIFF
--- a/.changeset/itchy-apes-happen.md
+++ b/.changeset/itchy-apes-happen.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: absolute url for virtual fields

--- a/packages/next-admin/src/components/Cell.tsx
+++ b/packages/next-admin/src/components/Cell.tsx
@@ -38,14 +38,18 @@ export default function Cell({ cell, formatter, copyable }: Props) {
       }
 
       if (cell.type === "link") {
+        const url = cell.isOverridden
+          ? cell.value.url
+          : `${basePath}/${cell.value.url}`;
+
         return (
           <Link
             onClick={(e) => e.stopPropagation()}
-            href={`${basePath}/${cell.value.url}`}
+            href={url}
             className="text-nextadmin-brand-emphasis dark:text-dark-nextadmin-brand-subtle hover:text-nextadmin-brand-emphasis dark:hover:text-dark-nextadmin-brand-emphasis flex cursor-pointer items-center gap-1 font-semibold hover:underline"
           >
             {cellValue}
-            {copyable && <Clipboard value={cell.value.url} />}
+            {copyable && <Clipboard value={url} />}
           </Link>
         );
       } else if (cell.type === "count") {

--- a/packages/next-admin/src/hooks/useDataColumns.tsx
+++ b/packages/next-admin/src/hooks/useDataColumns.tsx
@@ -113,7 +113,6 @@ const useDataColumns = ({
               const cellData = modelData[
                 propertyName as keyof ListFieldsOptions<ModelName>
               ] as unknown as ListDataFieldValue;
-
               const dataFormatter =
                 options?.list?.fields?.[
                   propertyName as keyof ListFieldsOptions<ModelName>

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -904,6 +904,7 @@ export type ListDataFieldValue = ListDataFieldValueWithFormat &
           label: string;
           url: string;
         };
+        isOverridden?: boolean;
       }
     | {
         type: "date";

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -637,6 +637,7 @@ export const mapDataList = ({
                 : undefined,
           __nextadmin_formatted:
             !appDir && typeof formatted === "string" ? undefined : formatted,
+          isOverridden: displayOpt.type === "link" ? true : undefined,
         };
       }
     });


### PR DESCRIPTION
## Title

Fix support for absolute URLs in virtual fields

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Fixes an issue where passing absolute urls in the result of the `url` function of a virtual field concatenated them with the base admin path.