### PR TITLE
feat: add custom input item data

### DIFF
--- a/.changeset/cuddly-bats-allow.md
+++ b/.changeset/cuddly-bats-allow.md
@@ -1,0 +1,6 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+feat: add custom input item data
+feat: add a new `utils` export, currently containing `useFormData`

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -885,8 +885,21 @@ Represents the props that are passed to the custom input component.
       type: "Boolean",
       description: "boolean indicating if the field is disabled",
     },
+    {
+      name: "item",
+      type: "any",
+      description: <>the <b>initial</b> value of the resource being edited</>,
+    },
   ]}
 />
+
+You can access the current form data state using the `useFormData` hook imported from `@premieroctet/next-admin/utils`.
+
+```tsx
+import { useFormData } from '@premieroctet/next-admin/utils'
+
+const { formData } = useFormData()
+```
 
 ## HookError
 

--- a/packages/next-admin/package.json
+++ b/packages/next-admin/package.json
@@ -71,6 +71,11 @@
       "import": "./dist/components/index.js",
       "types": "./dist/components/index.d.ts",
       "require": "./dist/components/index.js"
+    },
+    "./utils": {
+      "import": "./dist/utils/index.js",
+      "types": "./dist/utils/index.d.ts",
+      "require": "./dist/utils/index.js"
     }
   },
   "peerDependencies": {

--- a/packages/next-admin/src/components/Form.tsx
+++ b/packages/next-admin/src/components/Form.tsx
@@ -425,6 +425,7 @@ const Form = ({
           required: props.required,
           disabled: props.disabled,
           mode: edit ? "edit" : "create",
+          item: data,
         });
       }
 

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -1025,7 +1025,7 @@ export type NextAdminContext<ModelData = any> = {
   row?: ModelData;
 };
 
-export type CustomInputProps = Partial<{
+export type CustomInputProps<TItem extends any = any> = Partial<{
   name: string;
   value: string;
   onChange: (evt: ChangeEvent<HTMLInputElement>) => void;
@@ -1034,6 +1034,7 @@ export type CustomInputProps = Partial<{
   disabled: boolean;
   required?: boolean;
   mode: "create" | "edit";
+  item: TItem;
 }> &
   ComponentProps<"input">;
 

--- a/packages/next-admin/src/utils.ts
+++ b/packages/next-admin/src/utils.ts
@@ -1,0 +1,1 @@
+export { useFormData } from "./context/FormDataContext";


### PR DESCRIPTION
## Title

Add a new `item` prop to custom input props

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

https://github.com/premieroctet/next-admin/issues/405#issuecomment-2839923154

## Description

To be able to access the currently edited resource, this PR adds a new `item` prop that is passed to custom inputs. This is the *initial* value of the record. If we want to render stuff more dynamically, we can use the newly exported `useFormData` from `@premieroctet/next-admin/utils`
