### PR TITLE
fix: error on empty data list

### DIFF
--- a/.changeset/gold-rats-wait.md
+++ b/.changeset/gold-rats-wait.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: error with empty list when no display option is specified for a model

--- a/packages/next-admin/src/hooks/useDataColumns.tsx
+++ b/packages/next-admin/src/hooks/useDataColumns.tsx
@@ -54,11 +54,15 @@ const useDataColumns = ({
       });
     }
 
-    return Object.keys(data[0]).map((key) => ({
-      name: key,
-      virtual: false,
-      label: undefined,
-    }));
+    if (data?.[0]) {
+      return Object.keys(data[0]).map((key) => ({
+        name: key,
+        virtual: false,
+        label: undefined,
+      }));
+    }
+
+    return [];
   }, []);
 
   return useMemo<ColumnDef<ListDataItem<ModelName>>[]>(() => {


### PR DESCRIPTION
## Title

Fix a crash occurring on empty data lists when model list options has no display property

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#578

Thanks to @0xCucurbitaceae for the spot !
