### PR TITLE
fixes file required

### DIFF
--- a/packages/next-admin/src/components/inputs/FileWidget/FileWidget.tsx
+++ b/packages/next-admin/src/components/inputs/FileWidget/FileWidget.tsx
@@ -172,7 +172,13 @@ const FileWidget = (props: Props) => {
                 ref={inputRef}
                 id={props.id}
                 disabled={props.disabled}
-                required={!acceptsMultipleFiles ? props.required && (props.value !== null) : false}
+                required={
+                  acceptsMultipleFiles
+                    ? false
+                    : // if the value is null the field is already populated
+                      // but the <input file /> will be empty.
+                      props.required && props.value === null
+                }
                 name={props.name}
                 onChange={handleFileChange}
                 multiple={acceptsMultipleFiles}


### PR DESCRIPTION
## File Widget Fix

Fixed file widget required computation

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

No issue created

## Description

FileWidget was marking the `<input required />` if the field was already populated, making it impossible to submit the form without reuploading the file

## Testing

tested on my app
