### PR TITLE
fix: wrong utils export

### DIFF
--- a/.changeset/thirty-cars-warn.md
+++ b/.changeset/thirty-cars-warn.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: wrong utils export

--- a/packages/next-admin/package.json
+++ b/packages/next-admin/package.json
@@ -73,9 +73,9 @@
       "require": "./dist/components/index.js"
     },
     "./utils": {
-      "import": "./dist/utils/index.js",
-      "types": "./dist/utils/index.d.ts",
-      "require": "./dist/utils/index.js"
+      "import": "./dist/utils.js",
+      "types": "./dist/utils.d.ts",
+      "require": "./dist/utils.js"
     }
   },
   "peerDependencies": {


### PR DESCRIPTION
## Title

Fix the `@premieroctet/next-admin/utils` export path

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement