### PR TITLE
fix: page router formatters

### DIFF
--- a/.changeset/gorgeous-llamas-relate.md
+++ b/.changeset/gorgeous-llamas-relate.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": major
+---
+
+fix: page router formatters

--- a/.changeset/nasty-crabs-grin.md
+++ b/.changeset/nasty-crabs-grin.md
@@ -1,0 +1,7 @@
+---
+"@premieroctet/next-admin": major
+---
+
+feat: change the way to initialize globals
+
+This is a **Breaking Change**. This changes the `getMainLayoutProps` function to be asynchronous. This will mainly affect custom pages.

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Setup packages (Build)
         run: pnpm setup:packages
 
-      - name: Build examples
-        run: pnpm build:examples
-
       - name: Install Vercel CLI
         run: npm install --global vercel@37.6.1
 
@@ -63,9 +60,3 @@ jobs:
         run: vercel deploy ${{ inputs.extra_args }} --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_EXAMPLE }}
-      - uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: next-admin-build
-          path: .
-          retention-days: 1

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -63,3 +63,9 @@ jobs:
         run: vercel deploy ${{ inputs.extra_args }} --prebuilt --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_EXAMPLE }}
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: next-admin-build
+          path: .
+          retention-days: 1

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -30,7 +30,10 @@ jobs:
         run: pnpm install
 
       - name: Setup packages (Build)
-        run: pnpm build
+        run: pnpm setup:packages
+
+      - name: Build examples
+        run: pnpm build:examples
 
       - name: Install Vercel CLI
         run: npm install --global vercel@37.6.1

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ yarn-error.log*
 # E2E
 test-results
 playwright-report
+.vercel

--- a/apps/docs/pages/docs/code-snippets.mdx
+++ b/apps/docs/pages/docs/code-snippets.mdx
@@ -375,7 +375,7 @@ import { options } from "@/options";
 import { prisma } from "@/prisma";
 
 const CustomPage = async () => {
-  const mainLayoutProps = getMainLayoutProps({
+  const mainLayoutProps = await getMainLayoutProps({
     basePath: "/admin",
     apiBasePath: "/api/admin",
     /*options*/

--- a/apps/example-remix/app/routes/admin.custom.tsx
+++ b/apps/example-remix/app/routes/admin.custom.tsx
@@ -7,7 +7,7 @@ import { CustomPage } from "examples-common/components";
 import { options } from "../options";
 
 export const loader = async () => {
-  const mainLayoutProps = getMainLayoutProps({
+  const mainLayoutProps = await getMainLayoutProps({
     apiBasePath: "/api/admin",
     basePath: "/admin",
     options,

--- a/apps/example-start/app/functions/nextadmin.ts
+++ b/apps/example-start/app/functions/nextadmin.ts
@@ -29,7 +29,7 @@ export const getNextAdminPropsFn = createServerFn()
 export const getNextAdminCustomPageFn = createServerFn()
   // @ts-expect-error
   .handler(async () => {
-    const mainLayoutProps = getMainLayoutProps({
+    const mainLayoutProps = await getMainLayoutProps({
       basePath: "/admin",
       apiBasePath: "/api/admin",
       options,

--- a/apps/example/app/[locale]/admin/custom/page.tsx
+++ b/apps/example/app/[locale]/admin/custom/page.tsx
@@ -5,7 +5,7 @@ import { options } from "../../../../options";
 import { prisma } from "../../../../prisma";
 
 const CustomPage = async () => {
-  const mainLayoutProps = getMainLayoutProps({
+  const mainLayoutProps = await getMainLayoutProps({
     basePath: "/admin",
     apiBasePath: "/api/admin",
     options,

--- a/apps/example/next.config.js
+++ b/apps/example/next.config.js
@@ -5,7 +5,6 @@ const { withSuperjson } = require("next-superjson");
 module.exports = withNextIntl(
   withSuperjson({
     reactStrictMode: true,
-    serverExternalPackages: ["@premieroctet/next-admin"],
     experimental: {
       swcPlugins: [
         [
@@ -16,5 +15,6 @@ module.exports = withNextIntl(
         ],
       ],
     },
+    transpilePackages: ["@premieroctet/next-admin"],
   })
 );

--- a/apps/example/next.config.js
+++ b/apps/example/next.config.js
@@ -5,6 +5,7 @@ const { withSuperjson } = require("next-superjson");
 module.exports = withNextIntl(
   withSuperjson({
     reactStrictMode: true,
+    serverExternalPackages: ["@premieroctet/next-admin"],
     experimental: {
       swcPlugins: [
         [

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "cd ../../packages/database && pnpm generate && cd - && next build",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "test:e2e": "playwright test",

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "cd ../../packages/database && pnpm database && cd - && next build",
+    "build": "next build && cd ../../packages/database && pnpm database",
     "start": "next start",
     "lint": "next lint",
     "test:e2e": "playwright test",

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "cd ../../packages/database && pnpm database && cd - && next build",
     "start": "next start",
     "lint": "next lint",
     "test:e2e": "playwright test",

--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build && cd ../../packages/database && pnpm database",
+    "build": "cd ../../packages/database && pnpm generate && cd - && next build",
     "start": "next start",
     "lint": "next lint",
     "test:e2e": "playwright test",

--- a/apps/example/pages/pagerouter/admin/custom/index.tsx
+++ b/apps/example/pages/pagerouter/admin/custom/index.tsx
@@ -72,7 +72,7 @@ export default CustomPage;
 export const getServerSideProps: GetServerSideProps<Props> = async ({
   req,
 }) => {
-  const mainLayoutProps = getMainLayoutProps({
+  const mainLayoutProps = await getMainLayoutProps({
     basePath: "/pagerouter/admin",
     apiBasePath: "/api/pagerouter/admin",
     options: pageOptions,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:examples": "turbo run build --filter=example --filter=./apps/example-*",
     "build:next-admin": "turbo run build --filter=@premieroctet/next-admin",
     "build:packages": "turbo run build --filter=@premieroctet/next-admin --filter=@premieroctet/next-admin-cli --filter=@premieroctet/next-admin-generator-prisma --filter=@premieroctet/next-admin-json-schema",
-    "setup:packages": "turbo run build --filter=@premieroctet/next-admin-cli --filter=@premieroctet/next-admin-generator-prisma --filter=@premieroctet/next-admin-json-schema && pnpm build:next-admin",
+    "setup:packages": "turbo run build --filter=@premieroctet/next-admin-cli --filter=@premieroctet/next-admin-generator-prisma --filter=@premieroctet/next-admin-json-schema && pnpm build:next-admin && pnpm build --filter=examples-common",
     "dev": "turbo run dev",
     "dev:docs": "turbo run dev --filter=docs",
     "lint": "turbo run lint",

--- a/packages/examples-common/options.tsx
+++ b/packages/examples-common/options.tsx
@@ -242,6 +242,7 @@ export const options: NextAdminOptions = {
           "categories",
           "rate",
           "tags",
+          "author",
         ],
         filters: [
           {

--- a/packages/generator-prisma/src/index.ts
+++ b/packages/generator-prisma/src/index.ts
@@ -29,10 +29,14 @@ generatorHandler({
           : parseEnvValue(options.generator.output);
 
       await fs.mkdir(outputDir, { recursive: true });
-      await fs.writeFile(
-        path.join(outputDir, "schema.json"),
-        JSON.stringify(jsonSchema, null, 2)
-      );
+
+      const cjsContent = `module.exports = ${JSON.stringify(jsonSchema, null, 2)}`;
+
+      await fs.writeFile(path.join(outputDir, "schema.cjs"), cjsContent);
+
+      const mjsContent = `export default ${JSON.stringify(jsonSchema, null, 2)}`;
+
+      await fs.writeFile(path.join(outputDir, "schema.mjs"), mjsContent);
     }
   },
 });

--- a/packages/next-admin/package.json
+++ b/packages/next-admin/package.json
@@ -143,8 +143,8 @@
       }
     },
     "./schema": {
-      "import": "./dist/schema.json",
-      "require": "./dist/schema.json"
+      "import": "./dist/schema.mjs",
+      "require": "./dist/schema.cjs"
     }
   },
   "peerDependencies": {

--- a/packages/next-admin/src/appHandler.ts
+++ b/packages/next-admin/src/appHandler.ts
@@ -20,8 +20,8 @@ import {
   getModelIdProperty,
   getResourceFromParams,
   getResources,
-  globalSchema,
 } from "./utils/server";
+import { getSchema, initGlobals } from "./utils/globals";
 
 export const createHandler = <P extends string = "nextadmin">({
   apiBasePath,
@@ -31,10 +31,10 @@ export const createHandler = <P extends string = "nextadmin">({
   onRequest,
 }: CreateAppHandlerParams<P>) => {
   const router = createEdgeRouter<Request, RequestContext<P>>();
-  const resources = getResources(options);
 
   if (onRequest) {
     router.use(async (req, ctxPromise, next) => {
+      await initGlobals();
       const ctx = await ctxPromise;
       const response = await onRequest(req, ctx);
 
@@ -48,6 +48,7 @@ export const createHandler = <P extends string = "nextadmin">({
 
   router
     .get(`${apiBasePath}/:model/raw`, async (req, ctx) => {
+      const resources = getResources(options);
       const params = await ctx.params;
       const resource = getResourceFromParams(params[paramKey], resources);
 
@@ -84,6 +85,7 @@ export const createHandler = <P extends string = "nextadmin">({
       return Response.json(data);
     })
     .post(`${apiBasePath}/:model/actions/:id`, async (req, ctx) => {
+      const resources = getResources(options);
       const params = await ctx.params;
       const id = params[paramKey].at(-1)!;
 
@@ -137,6 +139,7 @@ export const createHandler = <P extends string = "nextadmin">({
       return Response.json(data);
     })
     .post(`${apiBasePath}/:model/order`, async (req, ctx) => {
+      const resources = getResources(options);
       const body = await req.json();
       const params = await ctx.params;
       const resource = getResourceFromParams(params[paramKey], resources);
@@ -175,6 +178,7 @@ export const createHandler = <P extends string = "nextadmin">({
       return Response.json({ ok: true });
     })
     .post(`${apiBasePath}/:model/:id?`, async (req, ctx) => {
+      const resources = getResources(options);
       const params = await ctx.params;
       const resource = getResourceFromParams(params[paramKey], resources);
 
@@ -210,7 +214,7 @@ export const createHandler = <P extends string = "nextadmin">({
           body: transformedBody ?? body,
           id,
           options,
-          schema: globalSchema,
+          schema: getSchema(),
         });
 
         if (response.error) {
@@ -236,6 +240,7 @@ export const createHandler = <P extends string = "nextadmin">({
       }
     })
     .delete(`${apiBasePath}/:model/:id`, async (req, ctx) => {
+      const resources = getResources(options);
       const params = await ctx.params;
       const resource = getResourceFromParams(params[paramKey], resources);
 
@@ -268,6 +273,7 @@ export const createHandler = <P extends string = "nextadmin">({
       }
     })
     .delete(`${apiBasePath}/:model`, async (req, ctx) => {
+      const resources = getResources(options);
       const params = await ctx.params;
       const resource = getResourceFromParams(params[paramKey], resources);
 

--- a/packages/next-admin/src/components/Cell.tsx
+++ b/packages/next-admin/src/components/Cell.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactElement, ReactNode } from "react";
 
 import clsx from "clsx";
 import Link from "./common/Link";
@@ -11,12 +11,22 @@ type Props = {
   cell: ListDataFieldValue;
   formatter?: (cell: any, context?: NextAdminContext) => ReactNode;
   copyable?: boolean;
+  getRawData?: () => any;
 };
 
-export default function Cell({ cell, formatter, copyable }: Props) {
+export default function Cell({ cell, formatter, copyable, getRawData }: Props) {
   const { basePath, nextAdminContext } = useConfig();
 
   let cellValue = cell?.__nextadmin_formatted;
+
+  const renderCustomElement = (val: ReactElement) => {
+    return (
+      <div className="flex gap-1">
+        {val}
+        {copyable && <Clipboard value={getDisplayedValue(val)} />}
+      </div>
+    );
+  };
 
   const isReactNode = (
     cell: ListDataFieldValue["__nextadmin_formatted"]
@@ -26,15 +36,14 @@ export default function Cell({ cell, formatter, copyable }: Props) {
 
   if (cell && cell !== null) {
     if (React.isValidElement(cellValue)) {
-      return (
-        <div className="flex gap-1">
-          {cellValue}
-          {copyable && <Clipboard value={getDisplayedValue(cellValue)} />}
-        </div>
-      );
+      return renderCustomElement(cellValue);
     } else if (typeof cell === "object" && !isReactNode(cellValue)) {
       if (formatter) {
-        cellValue = formatter(cell?.value, nextAdminContext);
+        cellValue = formatter(getRawData?.(), nextAdminContext);
+
+        if (React.isValidElement(cellValue)) {
+          return renderCustomElement(cellValue);
+        }
       }
 
       if (cell.type === "link") {

--- a/packages/next-admin/src/components/DataTable.tsx
+++ b/packages/next-admin/src/components/DataTable.tsx
@@ -270,7 +270,9 @@ export function DataTable({
                   {row.getVisibleCells().map((cell) => (
                     <TableCell
                       className={`group py-3 ${
-                        cell.column.id === "__nextadmin-actions" && "text-right"
+                        cell.column.id === "__nextadmin-actions"
+                          ? "text-right"
+                          : ""
                       }`}
                       key={cell.id}
                     >

--- a/packages/next-admin/src/components/Form.tsx
+++ b/packages/next-admin/src/components/Form.tsx
@@ -628,11 +628,18 @@ const Form = ({
   );
 };
 
-const FormWrapper = ({ clientActionsComponents, ...props }: FormProps) => {
+const FormWrapper = ({
+  clientActionsComponents,
+  relationshipsRawData,
+  ...props
+}: FormProps) => {
   return (
     <ClientActionDialogProvider componentsMap={clientActionsComponents}>
       <FormHeader {...props} />
-      <FormDataProvider data={props.data}>
+      <FormDataProvider
+        data={props.data}
+        relationshipsRawData={relationshipsRawData}
+      >
         <FormStateProvider>
           <Form {...props} />
         </FormStateProvider>

--- a/packages/next-admin/src/components/List.tsx
+++ b/packages/next-admin/src/components/List.tsx
@@ -61,6 +61,7 @@ export type ListProps = {
   icon?: ModelIcon;
   schema: Schema;
   clientActionsComponents?: AdminComponentProps["dialogComponents"];
+  rawData: any[];
 };
 
 function List({
@@ -73,6 +74,7 @@ function List({
   icon,
   schema,
   clientActionsComponents,
+  rawData,
 }: ListProps) {
   const { router, query } = useRouterInternal();
   const [isPending, startTransition] = useTransition();
@@ -97,6 +99,7 @@ function List({
     resourcesIdProperty,
     sortColumn,
     sortDirection,
+    rawData,
   });
 
   let onSearchChange;

--- a/packages/next-admin/src/components/NextAdmin.tsx
+++ b/packages/next-admin/src/components/NextAdmin.tsx
@@ -35,6 +35,8 @@ export function NextAdmin({
   user,
   externalLinks,
   pageLoader,
+  rawData,
+  relationshipsRawData,
 }: AdminComponentProps & CustomUIProps) {
   if (!isAppDir && !options) {
     throw new Error(
@@ -72,6 +74,7 @@ export function NextAdmin({
           icon={resourceIcon}
           schema={schema!}
           clientActionsComponents={dialogComponents}
+          rawData={rawData!}
         />
       );
     }
@@ -94,6 +97,7 @@ export function NextAdmin({
           icon={resourceIcon}
           resourcesIdProperty={resourcesIdProperty!}
           clientActionsComponents={dialogComponents}
+          relationshipsRawData={relationshipsRawData}
         />
       );
     }

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayTable.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectDisplayTable.tsx
@@ -12,6 +12,7 @@ type Props = {
   onRemoveClick: (value: any) => void;
   deletable: boolean;
   pagination?: RelationshipPagination;
+  rawData?: any[];
 };
 
 const MultiSelectDisplayTable = ({
@@ -20,6 +21,7 @@ const MultiSelectDisplayTable = ({
   deletable,
   onRemoveClick,
   pagination,
+  rawData,
 }: Props) => {
   const { resourcesIdProperty } = useConfig();
   const { dataToRender, handlePageChange, totalPages, pageIndex } =
@@ -34,6 +36,7 @@ const MultiSelectDisplayTable = ({
     resourcesIdProperty: resourcesIdProperty!,
     // @ts-expect-error
     resource: schema.items?.relation,
+    rawData,
   });
 
   return (

--- a/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectWidget.tsx
+++ b/packages/next-admin/src/components/inputs/MultiSelect/MultiSelectWidget.tsx
@@ -17,6 +17,7 @@ import { Selector } from "../Selector";
 import MultiSelectDisplayList from "./MultiSelectDisplayList";
 import MultiSelectDisplayTable from "./MultiSelectDisplayTable";
 import MultiSelectItem from "./MultiSelectItem";
+import { useFormData } from "../../../utils";
 
 type Props = {
   options?: Enumeration[];
@@ -37,6 +38,7 @@ const MultiSelectWidget = (props: Props) => {
   const { setFieldDirty } = useFormState();
   const fieldOptions =
     globalOptions?.model?.[resource!]?.edit?.fields?.[name as Field<ModelName>];
+  const { relationshipsRawData } = useFormData();
 
   const onRemoveClick = (value: any) => {
     setFieldDirty(name);
@@ -149,6 +151,7 @@ const MultiSelectWidget = (props: Props) => {
             onRemoveClick={onRemoveClick}
             deletable={!props.disabled}
             pagination={fieldPagination}
+            rawData={relationshipsRawData?.[name]}
           />
 
           <Button

--- a/packages/next-admin/src/context/FormDataContext.tsx
+++ b/packages/next-admin/src/context/FormDataContext.tsx
@@ -6,10 +6,12 @@ import {
   useState,
   Dispatch,
 } from "react";
+import { RelationshipsRawData } from "../types";
 
 const FormDataContext = createContext<{
   formData: any;
   setFormData: Dispatch<any>;
+  relationshipsRawData?: RelationshipsRawData;
 }>({
   formData: {},
   setFormData: () => {},
@@ -20,14 +22,20 @@ export const useFormData = () => useContext(FormDataContext);
 const FormDataProvider = ({
   data,
   children,
-}: PropsWithChildren<{ data: any }>) => {
+  relationshipsRawData,
+}: PropsWithChildren<{
+  data: any;
+  relationshipsRawData?: RelationshipsRawData;
+}>) => {
   const [formData, setFormData] = useState<any>(data);
   useEffect(() => {
     setFormData(data);
   }, [data]);
 
   return (
-    <FormDataContext.Provider value={{ formData, setFormData }}>
+    <FormDataContext.Provider
+      value={{ formData, setFormData, relationshipsRawData }}
+    >
       {children}
     </FormDataContext.Provider>
   );

--- a/packages/next-admin/src/handlers/resources.ts
+++ b/packages/next-admin/src/handlers/resources.ts
@@ -40,7 +40,6 @@ export const deleteResource = async ({
 }: DeleteResourceParams) => {
   const modelIdProperty = getModelIdProperty(resource);
 
-
   if (modelOptions?.middlewares?.delete) {
     // @ts-expect-error
     const resources = await prisma[uncapitalize(resource)].findMany({
@@ -171,14 +170,19 @@ export const submitResource = async ({
         });
       });
 
-      const data = await getDataItem({
+      const { data, relationshipsRawData } = await getDataItem({
         prisma,
         resource,
         resourceId: id,
         options,
       });
 
-      return { updated: true, data, redirect: redirect === "list" };
+      return {
+        updated: true,
+        data,
+        redirect: redirect === "list",
+        relationshipsRawData,
+      };
     }
 
     if (!hasPermission(options?.model?.[resource], Permission.CREATE)) {
@@ -200,7 +204,7 @@ export const submitResource = async ({
       data: complementaryFormattedData,
     });
 
-    const responseData = await getDataItem({
+    const { data: responseData, relationshipsRawData } = await getDataItem({
       prisma,
       resource,
       resourceId: data[resourceIdField],
@@ -212,6 +216,7 @@ export const submitResource = async ({
       createdId: data[resourceIdField],
       data: responseData,
       redirect: redirect === "list",
+      relationshipsRawData,
     };
   } catch (error: any) {
     if (

--- a/packages/next-admin/src/pageHandler.ts
+++ b/packages/next-admin/src/pageHandler.ts
@@ -63,11 +63,13 @@ export const createHandler = <P extends string = "nextadmin">({
 }: CreateAppHandlerParams<P>) => {
   const router = createRouter<NextApiRequest, NextApiResponse>();
 
+  router.use(async (req, res, next) => {
+    await initGlobals();
+    return next();
+  });
+
   if (onRequest) {
-    router.use(async (req, res, next) => {
-      await initGlobals();
-      return onRequest(req, res, next);
-    });
+    router.use(onRequest);
   }
 
   router

--- a/packages/next-admin/src/tests/prismaUtils.test.ts
+++ b/packages/next-admin/src/tests/prismaUtils.test.ts
@@ -1,6 +1,8 @@
 import { Decimal } from "@prisma/client/runtime/library";
+import cloneDeep from "lodash.clonedeep";
 import { describe, expect, it } from "vitest";
 import { getMappedDataList, optionsFromResource } from "../utils/prisma";
+import { extractSerializable } from "../utils/tools";
 import { options, prismaMock } from "./singleton";
 
 describe("getMappedDataList", () => {
@@ -32,6 +34,8 @@ describe("getMappedDataList", () => {
       },
     ];
 
+    const originalPostData = cloneDeep(postData);
+
     prismaMock.post.findMany.mockResolvedValueOnce(postData);
 
     prismaMock.post.count.mockResolvedValueOnce(2);
@@ -49,6 +53,7 @@ describe("getMappedDataList", () => {
       data: postData,
       total: postData.length,
       error: null,
+      rawData: extractSerializable(originalPostData),
     });
   });
 });

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -497,6 +497,8 @@ export type ListOptions<T extends ModelName> = {
   where?: Filter<T>[];
 };
 
+export type RelationshipsRawData = Record<string, any>;
+
 export type SubmitResourceResponse =
   | {
       error: string;
@@ -524,6 +526,7 @@ export type SubmitResourceResponse =
       created?: undefined;
       createdId?: undefined;
       validation?: undefined;
+      relationshipsRawData?: RelationshipsRawData;
     }
   | {
       error?: undefined;
@@ -533,6 +536,7 @@ export type SubmitResourceResponse =
       created: true;
       createdId: any;
       validation?: undefined;
+      relationshipsRawData?: RelationshipsRawData;
     };
 
 export type EditModelHooks = {
@@ -903,7 +907,7 @@ export type ListDataFieldValue = ListDataFieldValueWithFormat &
           label: string;
           url: string;
         };
-        isOverridden?: boolean;
+        isOverridden?: boolean | null;
       }
     | {
         type: "date";
@@ -926,6 +930,8 @@ export type AdminComponentProps = {
   apiBasePath: string;
   schema: Schema;
   data?: ListData<ModelName>;
+  rawData?: any[];
+  relationshipsRawData?: RelationshipsRawData;
   resource?: ModelName | null;
   slug?: string;
   /**
@@ -1230,6 +1236,7 @@ export type FormProps = {
   icon?: ModelIcon;
   resourcesIdProperty: Record<ModelName, string>;
   clientActionsComponents?: AdminComponentProps["dialogComponents"];
+  relationshipsRawData?: RelationshipsRawData;
 };
 
 export type ClientActionDialogContentProps<T extends ModelName> = Partial<{

--- a/packages/next-admin/src/utils/globals.ts
+++ b/packages/next-admin/src/utils/globals.ts
@@ -1,0 +1,40 @@
+import { ModelName, Schema } from "../types";
+
+let schema: Schema | null = null;
+let resources: ModelName[] | null = null;
+
+export const initGlobals = async () => {
+  try {
+    if (schema && resources) {
+      return;
+    }
+
+    // @ts-expect-error
+    const schemaDef = await import("@premieroctet/next-admin/schema");
+
+    schema = schemaDef.default as Schema;
+    resources = Object.keys(schema.definitions).filter((modelName) => {
+      // Enums are not resources
+      return !schema!.definitions[modelName as ModelName].enum;
+    }) as ModelName[];
+  } catch (e) {
+    console.error(e);
+    throw new Error(
+      "Schema not found, make sure you added the generator to your schema.prisma file"
+    );
+  }
+};
+
+export const getSchema = () => {
+  if (!schema) {
+    throw new Error("Schema not initialized");
+  }
+  return schema;
+};
+
+export const getResources = () => {
+  if (!resources) {
+    throw new Error("Resources not initialized");
+  }
+  return resources;
+};

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -28,7 +28,6 @@ import {
   findRelationInData,
   getModelIdProperty,
   getToStringForRelations,
-  globalSchema,
   modelHasIdField,
   transformData,
 } from "./server";
@@ -38,6 +37,7 @@ import {
   isScalar,
   uncapitalize,
 } from "./tools";
+import { getSchema } from "./globals";
 
 type CreateNestedWherePredicateParams<M extends ModelName> = {
   field: NextAdminJsonSchemaData & { name: string };
@@ -55,7 +55,7 @@ const createNestedWherePredicate = <M extends ModelName>(
   }: CreateNestedWherePredicateParams<M>,
   acc: Record<string, any> = {}
 ) => {
-  const resource = globalSchema.definitions[field.type as ModelName];
+  const resource = getSchema().definitions[field.type as ModelName];
   const resourceProperties = resource.properties;
 
   acc[field.name] = {
@@ -163,7 +163,7 @@ export const createWherePredicate = <M extends ModelName>({
 
             if (fieldNextAdmin?.kind === "enum" && fieldNextAdmin?.enum) {
               const enumDefinition = getDefinitionFromRef(
-                globalSchema,
+                getSchema(),
                 fieldNextAdmin.enum.$ref
               );
               const enumValueForSearchTerm = enumValueForEnumType(
@@ -231,7 +231,7 @@ const getFieldsFiltered = <M extends ModelName>(
   resource: M,
   options?: NextAdminOptions
 ): [string, SchemaProperty<M>[Field<M>]][] => {
-  const model = globalSchema.definitions[
+  const model = getSchema().definitions[
     resource
   ] as SchemaDefinitions[ModelName];
   const modelProperties = model.properties;
@@ -287,7 +287,7 @@ const preparePrismaListRequest = async <M extends ModelName>(
   options?: NextAdminOptions,
   skipFilters: boolean = false
 ): Promise<PrismaListRequest<M>> => {
-  const model = globalSchema.definitions[
+  const model = getSchema().definitions[
     resource
   ] as SchemaDefinitions[ModelName];
   const modelProperties = model.properties;
@@ -439,7 +439,7 @@ export const optionsFromResource = async ({
   )?.[property as Field<typeof originResource>]?.relationshipSearchField;
 
   if (relationshipField) {
-    const targetModel = globalSchema.definitions[args.resource];
+    const targetModel = getSchema().definitions[args.resource];
 
     if (!targetModel) {
       throw new Error(`Model ${args.resource} not found in schema`);
@@ -557,10 +557,7 @@ export const mapDataList = ({
 > & { fetchData: any[] }) => {
   const { resource, options } = args;
   const originalFetchData = cloneDeep(fetchData);
-  const data = findRelationInData(
-    fetchData,
-    globalSchema.definitions[resource]
-  );
+  const data = findRelationInData(fetchData, getSchema().definitions[resource]);
   const listFields = options?.model?.[resource]?.list?.fields ?? {};
   const listDisplayOptions = options?.model?.[resource]?.list?.display ?? [];
   const originalData = cloneDeep(data);
@@ -678,7 +675,7 @@ export const selectPayloadForModel = <M extends ModelName>(
   options?: EditOptions<M> | ListOptions<M>,
   level: "scalar" | "object" = "scalar"
 ) => {
-  const model = globalSchema.definitions[
+  const model = getSchema().definitions[
     resource
   ] as SchemaDefinitions[ModelName];
   const properties = model.properties;
@@ -765,8 +762,7 @@ export const getDataItem = async <M extends ModelName>({
   const edit = options?.model?.[resource]?.edit as EditOptions<typeof resource>;
   const idProperty = getModelIdProperty(resource);
   const select = selectPayloadForModel(resource, edit, "object");
-  const schemaResourceProperties =
-    globalSchema.definitions[resource].properties;
+  const schemaResourceProperties = getSchema().definitions[resource].properties;
 
   Object.entries(select).forEach(([key, value]) => {
     const fieldType =
@@ -857,7 +853,7 @@ const includeDataByDepth = <M extends ModelName>(
          */
         if (currentDepth < maxDepth - 1) {
           const nextModel =
-            globalSchema.definitions[field.__nextadmin.type as M].properties;
+            getSchema().definitions[field.__nextadmin.type as M].properties;
           acc[name] = {
             include: includeDataByDepth(nextModel, currentDepth + 1, maxDepth),
           };
@@ -891,7 +887,7 @@ export const getRawData = async <M extends ModelName>({
   resourceIds: Array<string | number>;
   maxDepth?: number;
 }): Promise<Model<M>[]> => {
-  const model = globalSchema.definitions[
+  const model = getSchema().definitions[
     resource
   ] as SchemaDefinitions[ModelName];
   const modelProperties = model.properties;

--- a/packages/next-admin/src/utils/props.ts
+++ b/packages/next-admin/src/utils/props.ts
@@ -22,10 +22,10 @@ import {
   getResourceIdFromParam,
   getResources,
   getToStringForModel,
-  globalSchema,
   transformSchema,
 } from "./server";
 import { extractSerializable } from "./tools";
+import { getSchema, initGlobals } from "./globals";
 
 enum Page {
   LIST = 1,
@@ -53,7 +53,13 @@ export async function getPropsFromParams({
     sidebar,
     resourcesIcons,
     externalLinks,
-  } = getMainLayoutProps({ basePath, apiBasePath, options, params, isAppDir });
+  } = await getMainLayoutProps({
+    basePath,
+    apiBasePath,
+    options,
+    params,
+    isAppDir,
+  });
 
   const clientOptions: NextAdminOptions | undefined =
     extractSerializable(options);
@@ -71,7 +77,7 @@ export async function getPropsFromParams({
     resourcesIcons,
     externalLinks,
     locale: locale ?? null,
-    schema: globalSchema,
+    schema: getSchema(),
   };
 
   if (!params) return defaultProps;
@@ -170,7 +176,7 @@ export async function getPropsFromParams({
         resource,
         edit,
         options
-      )(cloneDeep(globalSchema));
+      )(cloneDeep(getSchema()));
       const customInputs = isAppDir ? getCustomInputs(resource, options) : null;
 
       if (resourceId !== undefined) {
@@ -239,18 +245,20 @@ export async function getPropsFromParams({
   }
 }
 
-export const getMainLayoutProps = ({
+export const getMainLayoutProps = async ({
   basePath,
   apiBasePath,
   options,
   params,
   isAppDir = true,
-}: GetMainLayoutPropsParams): MainLayoutProps => {
+}: GetMainLayoutPropsParams): Promise<MainLayoutProps> => {
   if (params !== undefined && !Array.isArray(params)) {
     throw new Error(
       "`params` parameter in `getMainLayoutProps` should be an array of strings."
     );
   }
+
+  await initGlobals();
 
   const resources = getResources(options);
   const resource = getResourceFromParams(params ?? [], resources);
@@ -303,6 +311,6 @@ export const getMainLayoutProps = ({
     externalLinks: options?.externalLinks,
     options: extractSerializable(options, isAppDir),
     resourcesIdProperty: resourcesIdProperty,
-    schema: globalSchema,
+    schema: getSchema(),
   };
 };

--- a/packages/next-admin/src/utils/props.ts
+++ b/packages/next-admin/src/utils/props.ts
@@ -110,7 +110,7 @@ export async function getPropsFromParams({
 
   switch (params.length) {
     case Page.LIST: {
-      const { data, total, error } = await getMappedDataList({
+      const { data, total, error, rawData } = await getMappedDataList({
         prisma,
         resource,
         options,
@@ -156,6 +156,7 @@ export async function getPropsFromParams({
         error: error ?? (searchParams?.error as string) ?? null,
         actions: serializedActions,
         dialogComponents: dialogActionsComponents,
+        rawData: extractSerializable(rawData),
       };
     }
     case Page.EDIT: {
@@ -173,7 +174,7 @@ export async function getPropsFromParams({
       const customInputs = isAppDir ? getCustomInputs(resource, options) : null;
 
       if (resourceId !== undefined) {
-        const data = await getDataItem({
+        const { data, relationshipsRawData } = await getDataItem({
           prisma,
           resource,
           resourceId,
@@ -216,6 +217,10 @@ export async function getPropsFromParams({
           customInputs,
           actions: serializedActions,
           dialogComponents: dialogActionsComponents,
+          relationshipsRawData: extractSerializable(
+            relationshipsRawData,
+            isAppDir
+          ),
         };
       }
 

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -506,9 +506,7 @@ export const findRelationInData = (
               type: "link",
               value: {
                 label: item[property],
-                url: `${propertyType as ModelName}/${
-                  item[property][idProperty]
-                }`,
+                url: `${uncapitalize(propertyType as ModelName)}/${item[property][idProperty]}`,
               },
             };
           }

--- a/packages/next-admin/src/utils/server.ts
+++ b/packages/next-admin/src/utils/server.ts
@@ -3,7 +3,6 @@ import formidable from "formidable";
 import { IncomingMessage } from "http";
 import type { NextApiRequest } from "next";
 import { Writable } from "node:stream";
-import { createRequire } from "node:module";
 import {
   AdminFormData,
   EditFieldsOptions,
@@ -23,6 +22,7 @@ import {
   SchemaProperty,
   UploadedFile,
 } from "../types";
+import { getSchema, getResources as getResourcesInit } from "./globals";
 import { getRawData } from "./prisma";
 import {
   isFileUploadFormat,
@@ -32,28 +32,9 @@ import {
   uncapitalize,
 } from "./tools";
 
-const _require = createRequire(import.meta.url);
-
 export const getJsonSchema = (): Schema => {
-  try {
-    const schema = _require("@premieroctet/next-admin/schema");
-
-    return schema as Schema;
-  } catch (e) {
-    console.error(e);
-    throw new Error(
-      "Schema not found, make sure you added the generator to your schema.prisma file"
-    );
-  }
+  return getSchema();
 };
-
-export const globalSchema = getJsonSchema();
-export const resources = Object.keys(globalSchema.definitions).filter(
-  (modelName) => {
-    // Enums are not resources
-    return !globalSchema.definitions[modelName as ModelName].enum;
-  }
-) as ModelName[];
 
 export const enumValueForEnumType = (
   definition: Schema["definitions"][ModelName],
@@ -118,7 +99,7 @@ export const getEnableToExecuteActions = async <M extends ModelName>(
 };
 
 export const getModelIdProperty = (model: ModelName) => {
-  const schemaModel = globalSchema.definitions[model];
+  const schemaModel = getSchema().definitions[model];
 
   if (!schemaModel || !schemaModel.properties) {
     return "id";
@@ -139,7 +120,7 @@ const getDeepRelationModel = <M extends ModelName>(
   model: M,
   property: Field<M>
 ) => {
-  const schemaModel = globalSchema.definitions[
+  const schemaModel = getSchema().definitions[
     model
   ] as SchemaDefinitions[ModelName];
   const schemaModelProperty = schemaModel.properties;
@@ -150,7 +131,7 @@ const getDeepRelationModel = <M extends ModelName>(
 };
 
 export const modelHasIdField = (model: ModelName) => {
-  const schemaModel = globalSchema.definitions[model];
+  const schemaModel = getSchema().definitions[model];
   const schemaModelProperty = schemaModel.properties;
 
   return Object.entries(schemaModelProperty).some(
@@ -164,7 +145,7 @@ export const getResources = (
   const definedModels = options?.model
     ? (Object.keys(options.model) as Prisma.ModelName[])
     : [];
-  return definedModels.length > 0 ? definedModels : resources;
+  return definedModels.length > 0 ? definedModels : getResourcesInit();
 };
 
 export const getToStringForRelations = <M extends ModelName>(
@@ -355,7 +336,7 @@ export const transformData = <M extends ModelName>(
   options?: NextAdminOptions
 ) => {
   const modelName = resource;
-  const model = globalSchema.definitions[
+  const model = getSchema().definitions[
     modelName
   ] as SchemaDefinitions[ModelName];
   if (!model) return data;
@@ -615,7 +596,7 @@ export const parseFormData = <M extends ModelName>(
 };
 
 export const formatId = (resource: ModelName, id: string) => {
-  const model = globalSchema.definitions[
+  const model = getSchema().definitions[
     resource
   ] as SchemaDefinitions[ModelName];
   const modelProperties = model.properties;
@@ -631,7 +612,7 @@ export const formatId = (resource: ModelName, id: string) => {
 const getExplicitManyToManyTableFields = <M extends ModelName>(
   manyToManyResource: M
 ) => {
-  const model = globalSchema.definitions[
+  const model = getSchema().definitions[
     manyToManyResource
   ] as SchemaDefinitions[ModelName];
   const modelProperties = model.properties;
@@ -646,7 +627,7 @@ const getExplicitManyToManyTableFields = <M extends ModelName>(
 const getExplicitManyToManyTablePrimaryKey = <M extends ModelName>(
   resource: M
 ) => {
-  const model = globalSchema.definitions[
+  const model = getSchema().definitions[
     resource
   ] as SchemaDefinitions[ModelName];
 

--- a/packages/next-admin/src/utils/tools.ts
+++ b/packages/next-admin/src/utils/tools.ts
@@ -37,6 +37,8 @@ export const extractSerializable = <T>(obj: T, isAppDir?: boolean): T => {
     return obj.map((item) =>
       extractSerializable(item, isAppDir)
     ) as unknown as T;
+  } else if (obj instanceof Date) {
+    return obj.toISOString() as unknown as T;
   } else if (obj === null) {
     return obj;
   } else if (typeof obj === "object") {
@@ -137,7 +139,7 @@ export const reorderData = <T extends ListDataItem<ModelName>>(
       result[i][orderField].value = current + 1;
     }
   }
-  
+
   return sortBy(result, function (item) {
     return item[orderField].value;
   });

--- a/packages/next-admin/vitest.config.ts
+++ b/packages/next-admin/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "jsdom",
+    setupFiles: ["./vitest.setup.ts"],
   },
 });

--- a/packages/next-admin/vitest.setup.ts
+++ b/packages/next-admin/vitest.setup.ts
@@ -1,0 +1,3 @@
+import { initGlobals } from "./src/utils/globals";
+
+await initGlobals();

--- a/turbo.json
+++ b/turbo.json
@@ -16,8 +16,11 @@
     "database#generate:client-only": {
       "dependsOn": ["@premieroctet/next-admin-generator-prisma#build"]
     },
+    "example#build": {
+      "dependsOn": ["database#generate"]
+    },
     "build": {
-      "dependsOn": ["database#generate", "^build"],
+      "dependsOn": ["^build"],
       "outputs": [
         "dist/**",
         ".next/**",

--- a/turbo.json
+++ b/turbo.json
@@ -17,7 +17,7 @@
       "dependsOn": ["@premieroctet/next-admin-generator-prisma#build"]
     },
     "build": {
-      "dependsOn": ["^build"],
+      "dependsOn": ["database#generate", "^build"],
       "outputs": [
         "dist/**",
         ".next/**",


### PR DESCRIPTION
## Title

Fix formatters for page router

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

Fix formatters on Page Router which where working incorrectly. We now provide `rawData` on the List, which is the raw data thats coming from Prisma. For the edit page, we provide `relationshipsRawData` which contains the raw data of relationships, which is useful in case we have some fields displayed as tables, using the list formatters.

