### PR TITLE
fix: page router display for functional filters

### DIFF
--- a/.changeset/dirty-peas-divide.md
+++ b/.changeset/dirty-peas-divide.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": major
+---
+
+fix: page router display for functional filters

--- a/packages/next-admin/src/components/List.tsx
+++ b/packages/next-admin/src/components/List.tsx
@@ -62,6 +62,7 @@ export type ListProps = {
   schema: Schema;
   clientActionsComponents?: AdminComponentProps["dialogComponents"];
   rawData: any[];
+  listFilterOptions?: Array<FilterWrapper<ModelName>>;
 };
 
 function List({
@@ -75,6 +76,7 @@ function List({
   schema,
   clientActionsComponents,
   rawData,
+  listFilterOptions,
 }: ListProps) {
   const { router, query } = useRouterInternal();
   const [isPending, startTransition] = useTransition();
@@ -114,9 +116,6 @@ function List({
 
   const hasDeletePermission =
     !modelOptions?.permissions || modelOptions?.permissions?.includes("delete");
-
-  const filterOptions = modelOptions?.list
-    ?.filters as FilterWrapper<ModelName>[];
   if (
     !(modelOptions?.list?.search && modelOptions?.list?.search?.length === 0)
   ) {
@@ -282,7 +281,7 @@ function List({
         <div className="bg-nextadmin-background-default dark:bg-dark-nextadmin-background-default max-w-full p-4 align-middle sm:p-8">
           <div className="-mt-2 mb-2 space-y-4 sm:-mt-4 sm:mb-4">
             <Message />
-            <Filters filters={filterOptions!} />
+            <Filters filters={listFilterOptions!} />
           </div>
           <DataTable
             resource={resource}

--- a/packages/next-admin/src/components/NextAdmin.tsx
+++ b/packages/next-admin/src/components/NextAdmin.tsx
@@ -37,6 +37,7 @@ export function NextAdmin({
   pageLoader,
   rawData,
   relationshipsRawData,
+  listFilterOptions,
 }: AdminComponentProps & CustomUIProps) {
   if (!isAppDir && !options) {
     throw new Error(
@@ -75,6 +76,7 @@ export function NextAdmin({
           schema={schema!}
           clientActionsComponents={dialogComponents}
           rawData={rawData!}
+          listFilterOptions={listFilterOptions}
         />
       );
     }

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -932,6 +932,7 @@ export type AdminComponentProps = {
   data?: ListData<ModelName>;
   rawData?: any[];
   relationshipsRawData?: RelationshipsRawData;
+  listFilterOptions?: Array<FilterWrapper<ModelName>>;
   resource?: ModelName | null;
   slug?: string;
   /**

--- a/packages/next-admin/src/utils/props.ts
+++ b/packages/next-admin/src/utils/props.ts
@@ -3,6 +3,7 @@ import cloneDeep from "lodash.clonedeep";
 import {
   AdminComponentProps,
   EditOptions,
+  FilterWrapper,
   GetMainLayoutPropsParams,
   GetNextAdminPropsParams,
   MainLayoutProps,
@@ -163,6 +164,9 @@ export async function getPropsFromParams({
         actions: serializedActions,
         dialogComponents: dialogActionsComponents,
         rawData: extractSerializable(rawData),
+        listFilterOptions:
+          (clientOptions?.model?.[resource]?.list
+            ?.filters as FilterWrapper<ModelName>[]) ?? null,
       };
     }
     case Page.EDIT: {


### PR DESCRIPTION
## Title

Fix display of functional filters for page router, which was displaying the function name instead of the result of the function call

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement