### PR TITLE
Fix latency on list

### DIFF
--- a/.changeset/twelve-coats-occur.md
+++ b/.changeset/twelve-coats-occur.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+Fix request prisma latency on list

--- a/.changeset/twelve-coats-occur.md
+++ b/.changeset/twelve-coats-occur.md
@@ -3,3 +3,4 @@
 ---
 
 Fix request prisma latency on list
+`formatter` is now taking the count value as a parameter for OneToMany relation fields

--- a/apps/example/options.tsx
+++ b/apps/example/options.tsx
@@ -1,6 +1,6 @@
-import { faker } from "@faker-js/faker";
 import AddTagDialog from "@/components/PostAddTagDialogContent";
 import UserDetailsDialog from "@/components/UserDetailsDialogContent";
+import { faker } from "@faker-js/faker";
 import { NextAdminOptions } from "@premieroctet/next-admin";
 import DatePicker from "./components/DatePicker";
 import PasswordInput from "./components/PasswordInput";

--- a/packages/next-admin/src/tests/prismaUtils.test.ts
+++ b/packages/next-admin/src/tests/prismaUtils.test.ts
@@ -1,5 +1,5 @@
 import { Decimal } from "@prisma/client/runtime/library";
-import { any } from "jest-mock-extended";
+import { any, mockReset } from "jest-mock-extended";
 import { getMappedDataList, optionsFromResource } from "../utils/prisma";
 import { options, prismaMock } from "./singleton";
 
@@ -32,9 +32,9 @@ describe("getMappedDataList", () => {
       },
     ];
 
-    prismaMock.post.findMany.mockResolvedValueOnce(postData);
+    prismaMock.post.findMany.mockResolvedValue(postData);
 
-    prismaMock.post.count.mockResolvedValueOnce(2);
+    prismaMock.post.count.mockResolvedValue(2);
 
     const result = await getMappedDataList({
       prisma: prismaMock,
@@ -50,6 +50,10 @@ describe("getMappedDataList", () => {
       total: postData.length,
       error: null,
     });
+  });
+
+  afterEach(() => {
+    mockReset(prismaMock);
   });
 });
 
@@ -82,9 +86,9 @@ describe("optionsFromResource", () => {
       },
     ];
 
-    prismaMock.post.findMany.mockResolvedValueOnce(postData);
+    prismaMock.post.findMany.mockResolvedValue(postData);
 
-    prismaMock.post.count.mockResolvedValueOnce(2);
+    prismaMock.post.count.mockResolvedValue(2);
 
     const result = await optionsFromResource({
       prisma: prismaMock,
@@ -106,5 +110,9 @@ describe("optionsFromResource", () => {
       total: postData.length,
       error: null,
     });
+  });
+
+  afterEach(() => {
+    mockReset(prismaMock);
   });
 });

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -168,7 +168,7 @@ export type ListFieldsOptions<T extends ModelName> = {
      */
     formatter?: (
       item: P extends keyof ObjectField<T>
-        ? ObjectField<T>[P] extends []
+        ? ObjectField<T>[P] extends Array<any>
           ? number
           : ModelFromProperty<T, P>
         : Model<T>[P],

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -168,7 +168,9 @@ export type ListFieldsOptions<T extends ModelName> = {
      */
     formatter?: (
       item: P extends keyof ObjectField<T>
-        ? ModelFromProperty<T, P>
+        ? ObjectField<T>[P] extends []
+          ? number
+          : ModelFromProperty<T, P>
         : Model<T>[P],
       context?: NextAdminContext
     ) => ReactNode;

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -459,7 +459,7 @@ export const optionsFromResource = async ({
   const { data: dataItems, total, error } = data;
   const { resource } = args;
   const idProperty = getModelIdProperty(resource);
-  const dataTableItems = await mapDataList({
+  const dataTableItems = mapDataList({
     ...args,
     fetchData: cloneDeep(dataItems),
   });
@@ -563,7 +563,7 @@ const fetchDataList = async (
   };
 };
 
-export const mapDataList = async ({
+export const mapDataList = ({
   context,
   appDir,
   fetchData,
@@ -685,7 +685,7 @@ export const getMappedDataList = async ({
   const { data: fetchData, total, error } = await fetchDataList(args);
 
   return {
-    data: await mapDataList({ context, appDir, fetchData, ...args }),
+    data: mapDataList({ context, appDir, fetchData, ...args }),
     total,
     error,
   };

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -537,6 +537,7 @@ const fetchDataList = async (
           in: resourceIds.map((item: any) => item[idProperty]),
         },
       },
+      orderBy,
     });
     // @ts-expect-error
     total = await prisma[uncapitalize(resource)].count({


### PR DESCRIPTION
## Title

Fix latency issue from Prisma on list

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#581 

## Description

- Split the prisma request in the list, because of Prisma issue of latency when using `orderBy` and relation (even `count`)
- `formatter` function on list field take a number (count) for relation field OneToMany
- 
## Impact

`formatter` function for OneToMany relation field accepts no more object type


