### PR TITLE
feat: add support for tailwind 4

### DIFF
--- a/.changeset/lazy-cups-serve.md
+++ b/.changeset/lazy-cups-serve.md
@@ -1,0 +1,6 @@
+---
+"@premieroctet/next-admin": minor
+"@premieroctet/next-admin-cli": patch
+---
+
+feat: add support for Tailwind v4 (#573)

--- a/apps/docs/pages/docs/getting-started.mdx
+++ b/apps/docs/pages/docs/getting-started.mdx
@@ -60,7 +60,17 @@ pnpm add @premieroctet/next-admin @premieroctet/next-admin-generator-prisma
 
 Next-Admin relies on [TailwindCSS](https://tailwindcss.com/) for the style. If you do not have it, you can [install TailwindCSS](https://tailwindcss.com/docs/installation) with the following configuration :
 
-```typescript copy filename="tailwind.config.js"
+<Tabs items={["v4", "<=v3"]}>
+<Tabs.Tab>
+```css copy filename="styles.css"
+@import "tailwindcss";
+@import "@premieroctet/next-admin/theme";
+@source "./node_modules/@premieroctet/next-admin/dist";
+@source "./node_modules/examples-common/dist";
+```
+</Tabs.Tab>
+<Tabs.Tab>
+```javascript copy filename="tailwind.config.js"
 module.exports = {
   content: [
     "./node_modules/@premieroctet/next-admin/dist/**/*.{js,ts,jsx,tsx}",
@@ -69,6 +79,8 @@ module.exports = {
   presets: [require("@premieroctet/next-admin/preset")],
 };
 ```
+</Tabs.Tab>
+</Tabs>
 
 Then import your `.css` file containing Tailwind rules into a page file or a parent layout.
 

--- a/apps/docs/pages/docs/theming.mdx
+++ b/apps/docs/pages/docs/theming.mdx
@@ -1,4 +1,4 @@
-import { Callout } from "nextra/components";
+import { Callout, Tabs } from "nextra/components";
 
 # Theming
 
@@ -8,8 +8,16 @@ import { Callout } from "nextra/components";
 
 Next Admin comes with a preset that is used to theme the different components of the pages.
 
-You can add the preset to your Tailwind config presets :
+You can add the preset to your Tailwind config :
 
+<Tabs items={["v4", "<=v3"]}>
+<Tabs.Tab>
+```css
+@import "@premieroctet/next-admin/theme";
+@source "./node_modules/@premieroctet/next-admin/dist"
+```
+</Tabs.Tab>
+<Tabs.Tab>
 ```js
 module.exports = {
   content: [
@@ -19,15 +27,33 @@ module.exports = {
   presets: [require("@premieroctet/next-admin/preset")],
 };
 ```
+</Tabs.Tab>
+</Tabs>
 
 ## Dark mode support
 
-The preset sets the `darkMode` option to `class` by default. However, if you wish to adapt to the system's preferences, you can set it to `media` in your own config.
+The JS preset sets the `darkMode` option to `class` by default. However, if you wish to adapt to the system's preferences, you can set it to `media` in your own config.
+
+With the Tailwind v4 support, the dark mode option has to be set as a [variant with the name `dark`](https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually).
 
 ## Theme override
 
 You can override the default theme by extending the color palette in your Tailwind config.
 
+<Tabs items={["v4", "<=v3"]}>
+<Tabs.Tab>
+```css
+@import "tailwindcss";
+@import "@premieroctet/next-admin/theme";
+@source "./node_modules/@premieroctet/next-admin/dist";
+
+@theme {
+  --color-nextadmin-background-default: oklch(0.997 0 0);
+  --color-dark-nextadmin-background-default: oklch(0.3052 0 0);
+}
+```
+</Tabs.Tab>
+<Tabs.Tab>
 ```typescript
 module.exports = {
   content: [
@@ -55,5 +81,7 @@ module.exports = {
   presets: [require("@premieroctet/next-admin/preset")],
 };
 ```
+</Tabs.Tab>
+</Tabs>
 
 Make sure to respect the same structure as the one provided in the preset.

--- a/apps/example-start/styles.css
+++ b/apps/example-start/styles.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
-@config "./tailwind.config.js";
+@import "@premieroctet/next-admin/theme";
+@source "./node_modules/@premieroctet/next-admin/dist";
+@source "./node_modules/examples-common/dist";
+
+@custom-variant dark (&:where(.dark, .dark *));
 
 @layer base {
   button,

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -112,13 +112,16 @@ export const initAction = async ({
     process.exit(1);
   }
 
+  const packageDependencies = getPackageDependencies(basePath);
+
   spinner.text = "Creating Tailwind CSS configuration";
 
-  addTailwindCondig(basePath);
+  const tailwindVersion = packageDependencies.tailwindcss;
+  const isTailwindAtLeastV4 = semver.satisfies(tailwindVersion, ">=4");
+
+  addTailwindCondig(basePath, isTailwindAtLeastV4);
 
   spinner.text = "Get Next.js version";
-
-  const packageDependencies = getPackageDependencies(basePath);
 
   const nextDep = packageDependencies.next;
 

--- a/packages/cli/src/utils/tailwind.ts
+++ b/packages/cli/src/utils/tailwind.ts
@@ -7,11 +7,15 @@ import {
   NEXTADMIN_CSS_FILENAME,
 } from "./constants.js";
 
-export const addTailwindCondig = async (basePath: string) => {
-  const { stdout: libPath } =
-    await execa`node -p path.dirname(require.resolve('@premieroctet/next-admin'))`;
+export const addTailwindCondig = async (
+  basePath: string,
+  isAtLeastV4: boolean
+) => {
+  if (isAtLeastV4) {
+    const { stdout: libPath } =
+      await execa`node -p path.dirname(require.resolve('@premieroctet/next-admin'))`;
 
-  const content = `
+    const content = `
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
@@ -24,13 +28,17 @@ module.exports = {
 };
   `;
 
-  writeFileSync(
-    path.join(basePath, NEXTADMIN_TAILWIND_CONFIG_FILENAME),
-    content
-  );
+    writeFileSync(
+      path.join(basePath, NEXTADMIN_TAILWIND_CONFIG_FILENAME),
+      content
+    );
+  }
 
-  const adminCssContent = `
-@config "./${NEXTADMIN_TAILWIND_CONFIG_FILENAME}";
+  const adminCssContent = isAtLeastV4
+    ? `@import "tailwindcss";
+@import "@premieroctet/next-admin/theme";
+@source "./node_modules/@premieroctet/next-admin/dist";`
+    : `@config "./${NEXTADMIN_TAILWIND_CONFIG_FILENAME}";
 
 @tailwind base;
 @tailwind components;

--- a/packages/next-admin/package.json
+++ b/packages/next-admin/package.json
@@ -145,6 +145,11 @@
     "./schema": {
       "import": "./dist/schema.mjs",
       "require": "./dist/schema.cjs"
+    },
+    "./theme": {
+      "import": "./dist/theme.css",
+      "require": "./dist/theme.css",
+      "default": "./dist/theme.css"
     }
   },
   "peerDependencies": {

--- a/packages/next-admin/package.json
+++ b/packages/next-admin/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://next-admin.js.org/",
   "license": "MIT",
   "scripts": {
-    "build": "rollup -c --configPlugin typescript",
+    "build": "rollup -c --configPlugin typescript && cp src/theme.css dist/theme.css",
     "dev": "rollup -c --configPlugin typescript --watch",
     "lint": "eslint \"**/*.{ts,tsx}\"",
     "test": "vitest",

--- a/packages/next-admin/rollup.config.ts
+++ b/packages/next-admin/rollup.config.ts
@@ -2,9 +2,22 @@ import typescript from "@rollup/plugin-typescript";
 import { glob } from "glob";
 import { defineConfig } from "rollup";
 import preserveDirectives from "rollup-preserve-directives";
+import { copyFileSync } from "node:fs";
 
 export default defineConfig({
-  plugins: [typescript(), preserveDirectives()],
+  plugins: [
+    typescript(),
+    preserveDirectives(),
+    {
+      name: "cp-theme-css",
+      buildStart: function () {
+        this.addWatchFile("src/theme.css");
+      },
+      buildEnd: function () {
+        copyFileSync("src/theme.css", "dist/theme.css");
+      },
+    },
+  ],
   input: glob.sync("src/**/*.{ts,tsx}", {
     ignore: ["**/tests/*", "**/*.test.{ts,tsx}"],
   }),

--- a/packages/next-admin/rollup.config.ts
+++ b/packages/next-admin/rollup.config.ts
@@ -3,6 +3,14 @@ import { glob } from "glob";
 import { defineConfig } from "rollup";
 import preserveDirectives from "rollup-preserve-directives";
 import { copyFileSync } from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const basePath = path.dirname(fileURLToPath(import.meta.url));
+
+const themeCssPath = path.resolve(basePath, "src/theme.css");
+
+console.log("themeCssPath", themeCssPath);
 
 export default defineConfig({
   plugins: [
@@ -11,10 +19,15 @@ export default defineConfig({
     {
       name: "cp-theme-css",
       buildStart: function () {
-        this.addWatchFile("src/theme.css");
+        if (this.meta.watchMode) {
+          this.addWatchFile(themeCssPath);
+        }
       },
       buildEnd: function () {
-        copyFileSync("src/theme.css", "dist/theme.css");
+        // TODO: this only work in watch mode but not in build mode ?????
+        if (this.meta.watchMode) {
+          copyFileSync(themeCssPath, path.resolve(basePath, "dist/theme.css"));
+        }
       },
     },
   ],

--- a/packages/next-admin/rollup.config.ts
+++ b/packages/next-admin/rollup.config.ts
@@ -10,8 +10,6 @@ const basePath = path.dirname(fileURLToPath(import.meta.url));
 
 const themeCssPath = path.resolve(basePath, "src/theme.css");
 
-console.log("themeCssPath", themeCssPath);
-
 export default defineConfig({
   plugins: [
     typescript(),

--- a/packages/next-admin/src/components/ColorSchemeSwitch.tsx
+++ b/packages/next-admin/src/components/ColorSchemeSwitch.tsx
@@ -20,7 +20,7 @@ const ColorSchemeSwitch = () => {
     <div
       onClick={toggleColorScheme}
       role="button"
-      className="text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color hover:text-nextadmin-menu-emphasis hover:bg-nextadmin-menu-muted dark:hover:bg-dark-nextadmin-menu-muted flex cursor-pointer select-none flex-row items-center gap-5 rounded-lg p-3 text-sm font-medium transition-colors"
+      className="text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color hover:text-nextadmin-menu-emphasis dark:hover:text-dark-nextadmin-menu-emphasis hover:bg-nextadmin-menu-muted dark:hover:bg-dark-nextadmin-menu-muted flex cursor-pointer select-none flex-row items-center gap-5 rounded-lg p-3 text-sm font-medium transition-colors"
       suppressHydrationWarning
     >
       {colorSchemeIcon}

--- a/packages/next-admin/src/components/List.tsx
+++ b/packages/next-admin/src/components/List.tsx
@@ -178,7 +178,11 @@ function List({
       return (
         <Dropdown>
           <DropdownTrigger asChild>
-            <Button variant="ghost" size="sm" className="!px-2 py-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="hover:bg-nextadmin-background-emphasis !px-2 py-2"
+            >
               <EllipsisVerticalIcon className="text-nextadmin-content-default dark:text-dark-nextadmin-content-default h-6 w-6" />
             </Button>
           </DropdownTrigger>

--- a/packages/next-admin/src/components/Menu.tsx
+++ b/packages/next-admin/src/components/Menu.tsx
@@ -89,7 +89,7 @@ export default function Menu({
         className={clsx(
           item.current
             ? "bg-nextadmin-menu-muted dark:bg-dark-nextadmin-menu-muted dark:text-dark-nextadmin-menu-emphasis text-nextadmin-menu-emphasis"
-            : "text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color dark:hover:bg-dark-nextadmin-menu-muted hover:bg-nextadmin-menu-muted hover:text-nextadmin-menu-emphasis",
+            : "text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color dark:hover:bg-dark-nextadmin-menu-muted hover:bg-nextadmin-menu-muted hover:text-nextadmin-menu-emphasis dark:hover:text-dark-nextadmin-menu-emphasis",
           "group flex items-center gap-x-2 rounded-lg px-3 py-2 text-sm leading-6 transition-colors"
         )}
       >
@@ -153,8 +153,6 @@ export default function Menu({
       }
     };
 
-    const hasDropdown = user.logout; // Add more conditions here if needed
-
     return (
       <div className="text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color flex flex-1 items-center gap-1 px-2 py-3 text-sm font-semibold leading-6">
         <div className="flex min-w-0 flex-1 items-center gap-3">
@@ -182,7 +180,7 @@ export default function Menu({
         <Button
           variant="ghost"
           size="sm"
-          className="flex-grow-1 order-2 flex-shrink-0 basis-auto !px-2 py-2"
+          className="order-2 flex-shrink-0 basis-auto !px-2 py-2"
           type="button"
           onClick={logoutBind}
         >
@@ -201,7 +199,7 @@ export default function Menu({
       <Link
         key={link.url}
         href={link.url}
-        className="text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color hover:text-nextadmin-menu-emphasis hover:bg-nextadmin-menu-muted dark:hover:bg-dark-nextadmin-menu-muted flex flex-row items-center justify-between gap-2 rounded-lg p-3 text-sm font-medium transition-colors"
+        className="text-nextadmin-menu-color dark:text-dark-nextadmin-menu-color hover:text-nextadmin-menu-emphasis dark:hover:text-dark-nextadmin-menu-emphasis hover:bg-nextadmin-menu-muted dark:hover:bg-dark-nextadmin-menu-muted flex flex-row items-center justify-between gap-2 rounded-lg p-3 text-sm font-medium transition-colors"
         target="_blank"
         rel="noopener"
       >

--- a/packages/next-admin/src/hooks/useDataColumns.tsx
+++ b/packages/next-admin/src/hooks/useDataColumns.tsx
@@ -166,17 +166,19 @@ const useDataColumns = ({
       : [];
   }, [
     data,
+    allDisplayedFields,
+    t,
+    resource,
+    options?.aliases,
     options?.list?.display,
     options?.list?.fields,
     options?.list?.copy,
-    options?.aliases,
+    sortable,
     sortDirection,
     sortColumn,
-    sortable,
     router,
     query,
     isAppDir,
-    resourcesIdProperty,
     rawData,
   ]);
 };

--- a/packages/next-admin/src/theme.css
+++ b/packages/next-admin/src/theme.css
@@ -1,0 +1,97 @@
+@theme {
+  /* Light */
+  --color-nextadmin-primary-50: var(--color-indigo-50);
+  --color-nextadmin-primary-100: var(--color-indigo-100);
+  --color-nextadmin-primary-200: var(--color-indigo-200);
+  --color-nextadmin-primary-300: var(--color-indigo-300);
+  --color-nextadmin-primary-400: var(--color-indigo-400);
+  --color-nextadmin-primary-500: var(--color-indigo-500);
+  --color-nextadmin-primary-600: var(--color-indigo-600);
+  --color-nextadmin-primary-700: var(--color-indigo-700);
+  --color-nextadmin-primary-800: var(--color-indigo-800);
+  --color-nextadmin-primary-900: var(--color-indigo-900);
+  --color-nextadmin-primary-950: var(--color-indigo-950);
+
+  --color-nextadmin-brand-subtle: var(--color-indigo-500);
+  --color-nextadmin-brand-default: var(--color-indigo-600);
+  --color-nextadmin-brand-emphasis: var(--color-indigo-700);
+  --color-nextadmin-brand-inverted: var(--color-white);
+  --color-nextadmin-brand-muted: var(--color-slate-100);
+
+  --color-nextadmin-menu-background: var(--color-slate-50);
+  --color-nextadmin-menu-color: var(--color-slate-500);
+  --color-nextadmin-menu-muted: var(--color-indigo-100);
+  --color-nextadmin-menu-emphasis: var(--color-indigo-700);
+
+  --color-nextadmin-border-default: var(--color-slate-200);
+  --color-nextadmin-border-strong: var(--color-slate-300);
+
+  --color-nextadmin-background-default: var(--color-white);
+  --color-nextadmin-background-subtle: var(--color-slate-50);
+  --color-nextadmin-background-muted: var(--color-slate-100);
+  --color-nextadmin-background-emphasis: var(--color-slate-200);
+
+  --color-nextadmin-content-default: var(--color-gray-400);
+  --color-nextadmin-content-subtle: var(--color-neutral-600);
+  --color-nextadmin-content-emphasis: var(--color-slate-500);
+  --color-nextadmin-content-inverted: var(--color-gray-700);
+
+  --color-nextadmin-alert-info-background: var(--color-blue-50);
+  --color-nextadmin-alert-info-content: var(--color-blue-800);
+  --color-nextadmin-alert-success-background: var(--color-green-50);
+  --color-nextadmin-alert-success-content: var(--color-green-800);
+  --color-nextadmin-alert-error-background: var(--color-red-50);
+  --color-nextadmin-alert-error-content: var(--color-red-800);
+
+  /* Dark */
+  --color-dark-nextadmin-primary-50: var(--color-indigo-50);
+  --color-dark-nextadmin-primary-100: var(--color-indigo-100);
+  --color-dark-nextadmin-primary-200: var(--color-indigo-200);
+  --color-dark-nextadmin-primary-300: var(--color-indigo-300);
+  --color-dark-nextadmin-primary-400: var(--color-indigo-400);
+  --color-dark-nextadmin-primary-500: var(--color-indigo-500);
+  --color-dark-nextadmin-primary-600: var(--color-indigo-600);
+  --color-dark-nextadmin-primary-700: var(--color-indigo-700);
+  --color-dark-nextadmin-primary-800: var(--color-indigo-800);
+  --color-dark-nextadmin-primary-900: var(--color-indigo-900);
+  --color-dark-nextadmin-primary-950: var(--color-indigo-950);
+
+  --color-dark-nextadmin-brand-subtle: var(--color-indigo-400);
+  --color-dark-nextadmin-brand-default: var(--color-indigo-500);
+  --color-dark-nextadmin-brand-emphasis: var(--color-indigo-700);
+  --color-dark-nextadmin-brand-inverted: var(--color-white);
+  --color-dark-nextadmin-brand-muted: var(--color-slate-50);
+
+  --color-dark-nextadmin-menu-background: var(--color-slate-800);
+  --color-dark-nextadmin-menu-color: var(--color-slate-300);
+  --color-dark-nextadmin-menu-muted: var(--color-slate-600);
+  --color-dark-nextadmin-menu-emphasis: var(--color-slate-200);
+
+  --color-dark-nextadmin-border-default: var(--color-slate-600);
+  --color-dark-nextadmin-border-strong: var(--color-slate-700);
+
+  --color-dark-nextadmin-background-default: var(--color-slate-900);
+  --color-dark-nextadmin-background-subtle: var(--color-slate-600);
+  --color-dark-nextadmin-background-muted: var(--color-slate-500);
+  --color-dark-nextadmin-background-emphasis: var(--color-slate-800);
+
+  --color-dark-nextadmin-content-default: var(--color-gray-300);
+  --color-dark-nextadmin-content-subtle: var(--color-neutral-200);
+  --color-dark-nextadmin-content-emphasis: var(--color-slate-400);
+  --color-dark-nextadmin-content-inverted: var(--color-slate-50);
+
+  --color-dark-nextadmin-alert-info-background: var(--color-slate-600);
+  --color-dark-nextadmin-alert-info-content: var(--color-sky-200);
+  --color-dark-nextadmin-alert-success-background: var(--color-slate-600);
+  --color-dark-nextadmin-alert-success-content: var(--color-green-400);
+  --color-dark-nextadmin-alert-error-background: var(--color-slate-600);
+  --color-dark-nextadmin-alert-error-content: var(--color-red-400);
+}
+
+body {
+  background-color: var(--color-nextadmin-background-default);
+
+  @variant dark {
+    background-color: var(--color-dark-nextadmin-background-default);
+  }
+}


### PR DESCRIPTION
## Title

Add support for tailwind 4 by providing a CSS file for theming

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#573 

## Description

Provide a theme CSS file that can be imported in main app CSS file to be used with Tailwind 4.

## Additional Information

Maintenance wise, this has the impact to require the maintenance of 2 files for theming. In the future, we might want to deprecate Tailwind 3, but this is not a really big deal as the theme is not that big.
