### PR TITLE
fix: advanced search on simple relations

### DIFF
--- a/.changeset/blue-dots-fly.md
+++ b/.changeset/blue-dots-fly.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: advanced search on simple relations (#602)

--- a/packages/next-admin/src/components/advancedSearch/AdvancedSearchDropdownItem.tsx
+++ b/packages/next-admin/src/components/advancedSearch/AdvancedSearchDropdownItem.tsx
@@ -36,10 +36,7 @@ const AdvancedSearchDropdownItem = ({
     schemaDef.properties[property as keyof typeof schemaDef.properties];
   const hasChildren = isSchemaPropertyScalarArray(schemaDef, property)
     ? false
-    : schemaProperty?.$ref ||
-      // @ts-expect-error
-      schemaProperty?.anyOf?.[0]?.$ref ||
-      schemaProperty?.type === "array";
+    : schemaProperty?.__nextadmin?.relation || schemaProperty?.type === "array";
   const [openChildren, setOpenChildren] = useState(false);
 
   const childResource = useMemo(() => {
@@ -50,8 +47,7 @@ const AdvancedSearchDropdownItem = ({
     const modelRef =
       schemaProperty?.type === "array"
         ? schemaProperty?.items?.$ref
-        : // @ts-expect-error
-          (schemaProperty?.anyOf?.[0]?.$ref ?? schemaProperty?.$ref);
+        : schemaProperty?.__nextadmin?.relation?.$ref;
 
     const model = modelRef?.split("/")?.at(-1);
 

--- a/packages/next-admin/src/utils/advancedSearch.test.ts
+++ b/packages/next-admin/src/utils/advancedSearch.test.ts
@@ -29,9 +29,18 @@ const schema: JSONSchema4 = {
           items: {
             $ref: "#/definitions/Test3",
           },
+          __nextadmin: {
+            relation: {
+              $ref: "#/definitions/Test3",
+            },
+          },
         },
         test5: {
-          $ref: "#/definitions/Test5",
+          __nextadmin: {
+            relation: {
+              $ref: "#/definitions/Test5",
+            },
+          },
         },
         testBool: {
           type: "boolean",
@@ -65,6 +74,11 @@ const schema: JSONSchema4 = {
           type: "array",
           items: {
             $ref: "#/definitions/Test5",
+          },
+          __nextadmin: {
+            relation: {
+              $ref: "#/definitions/Test5",
+            },
           },
         },
       },

--- a/packages/next-admin/src/utils/advancedSearch.ts
+++ b/packages/next-admin/src/utils/advancedSearch.ts
@@ -330,9 +330,8 @@ export const buildUIBlocks = <M extends ModelName>(
                 }
 
                 const childResourceName = (
-                  isArrayConditionKey
-                    ? schemaProperty.items?.$ref || (schemaProperty?.anyOf?.[0] as JSONSchema7)?.$ref
-                    : schemaProperty.$ref || (schemaProperty?.anyOf?.[0] as JSONSchema7)?.$ref
+                  schemaProperty.__nextadmin?.relation?.$ref ||
+                  (schemaProperty?.anyOf?.[0] as JSONSchema7)?.$ref
                 )
                   ?.split("/")
                   ?.at(-1)! as keyof typeof schema.definitions;
@@ -476,7 +475,9 @@ export const buildQueryBlocks = <M extends ModelName>(
             has: getValueForUiBlock(block),
           });
         } else {
-          const childResource = schemaProperty.items?.$ref?.split("/")?.at(-1)!;
+          const childResource = schemaProperty.__nextadmin?.relation?.$ref
+            ?.split("/")
+            ?.at(-1)!;
 
           if (!get(acc, [path, basePath].filter(Boolean))) {
             set(acc, [path, basePath].filter(Boolean).join("."), {
@@ -500,11 +501,12 @@ export const buildQueryBlocks = <M extends ModelName>(
         }
       } else if (
         schemaProperty &&
-        (schemaProperty?.$ref || (schemaProperty?.anyOf?.[0] as JSONSchema7)?.$ref)
+        (schemaProperty?.__nextadmin?.relation?.$ref ||
+          (schemaProperty?.anyOf?.[0] as JSONSchema7)?.$ref)
       ) {
         const ref =
-          schemaProperty.$ref ||
-          (schemaProperty.anyOf?.[0] as JSONSchema7)?.$ref;
+          schemaProperty?.__nextadmin?.relation?.$ref ||
+          (schemaProperty?.anyOf?.[0] as JSONSchema7)?.$ref;
         const childResource = ref!.split("/").at(-1)!;
 
         if (!get(acc, [path, basePath].filter(Boolean))) {


### PR DESCRIPTION
## Title

Fix advanced search displaying incorrectly for some relations

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#602 

## Description

In some cases, we were incorrectly displaying some relations in the advanced search dropdown like if they were scalar fields, which is incorrect since we cannot apply search on them. This was because we were not referring to the `$ref` that was part of the `__nextadmin` field in the json schema.

