### PR TITLE
fix: initGlobals in app handler

### DIFF
--- a/.changeset/eighty-moles-remember.md
+++ b/.changeset/eighty-moles-remember.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: initGlobals app handler (#605)

--- a/packages/next-admin/src/appHandler.ts
+++ b/packages/next-admin/src/appHandler.ts
@@ -32,9 +32,13 @@ export const createHandler = <P extends string = "nextadmin">({
 }: CreateAppHandlerParams<P>) => {
   const router = createEdgeRouter<Request, RequestContext<P>>();
 
+  router.use(async (req, res, next) => {
+    await initGlobals();
+    return next();
+  });
+
   if (onRequest) {
     router.use(async (req, ctxPromise, next) => {
-      await initGlobals();
       const ctx = await ctxPromise;
       const response = await onRequest(req, ctx);
 


### PR DESCRIPTION
## Title

Fixes the way we call `initGlobals` in app handler for API.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#605 