### PR TITLE
fix: default value for many to many in form

### DIFF
--- a/.changeset/loud-tables-protect.md
+++ b/.changeset/loud-tables-protect.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: default value for many to many in form (#605)

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -758,26 +758,25 @@ export const selectPayloadForModel = <M extends ModelName>(
                 [name]: true,
               },
             };
-          } else {
-            acc[name] = {
-              select: selectPayloadForModel(
-                fieldNextAdmin.type as ModelName,
-                {},
-                "scalar"
-              ),
+          }
+          acc[name] = {
+            select: selectPayloadForModel(
+              fieldNextAdmin.type as ModelName,
+              {},
+              "scalar"
+            ),
+          };
+
+          const orderField =
+            (options as EditOptions<M>)?.fields?.[
+              name as Field<M>
+              // @ts-expect-error
+            ]?.orderField || (options as ListOptions<M>)?.orderField;
+
+          if (orderField) {
+            acc[name].orderBy = {
+              [orderField]: "asc",
             };
-
-            const orderField =
-              (options as EditOptions<M>)?.fields?.[
-                name as Field<M>
-                // @ts-expect-error
-              ]?.orderField || (options as ListOptions<M>)?.orderField;
-
-            if (orderField) {
-              acc[name].orderBy = {
-                [orderField]: "asc",
-              };
-            }
           }
         } else {
           acc[name] = true;


### PR DESCRIPTION
## Title

Fix default value that's displayed in the form for many-to-many relationships

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#605 

