### PR TITLE
feat: add default list size option

### DIFF
--- a/.changeset/polite-birds-relate.md
+++ b/.changeset/polite-birds-relate.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": minor
+---
+
+feat: add default list size option (#616)

--- a/apps/docs/pages/docs/api/model-configuration.mdx
+++ b/apps/docs/pages/docs/api/model-configuration.mdx
@@ -224,6 +224,15 @@ This property determines how your data is displayed in the [list View](/docs/glo
         </>
       ),
     },
+    {
+      name: "defaultListSize",
+      type: "Number",
+      description: (
+        <>
+          the default number of items to display per page. It is optional. Defaults to 10.
+        </>
+      ),
+    },
   ]}
 />
 <Callout type="info">

--- a/packages/next-admin/src/types.ts
+++ b/packages/next-admin/src/types.ts
@@ -497,6 +497,10 @@ export type ListOptions<T extends ModelName> = {
    * define a set of Prisma filters that are always active in list
    */
   where?: Filter<T>[];
+  /**
+   * an optional number indicating the default amount of items in the list
+   */
+  defaultListSize?: number;
 };
 
 export type RelationshipsRawData = Record<string, any>;

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -302,7 +302,9 @@ const preparePrismaListRequest = async <M extends ModelName>(
   } catch {}
   const page = Number(searchParams.get("page")) || 1;
   const itemsPerPage =
-    Number(searchParams.get("itemsPerPage")) || ITEMS_PER_PAGE;
+    Number(searchParams.get("itemsPerPage")) ||
+    options?.model?.[resource]?.list?.defaultListSize ||
+    ITEMS_PER_PAGE;
 
   const fieldSort = options?.model?.[resource]?.list?.defaultSort;
 


### PR DESCRIPTION
## Title

Add an option for the default size of a resource list

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

#616 

