### PR TITLE
fix: avoid fetching list relation records in list view

### DIFF
--- a/.changeset/tender-experts-stop.md
+++ b/.changeset/tender-experts-stop.md
@@ -1,0 +1,5 @@
+---
+"@premieroctet/next-admin": patch
+---
+
+fix: avoid fetching list relation records in list view, only count is needed

--- a/packages/next-admin/src/utils/prisma.ts
+++ b/packages/next-admin/src/utils/prisma.ts
@@ -401,7 +401,7 @@ const preparePrismaListRequest = async <M extends ModelName>(
   let select: Select<M> | undefined;
   let where = {};
   const list = options?.model?.[resource]?.list as ListOptions<M>;
-  select = selectPayloadForModel(resource, list, "object");
+  select = selectPayloadForModel(resource, list, "object", "list");
   where = createWherePredicate({
     resource,
     options,
@@ -715,7 +715,8 @@ const isVirtualField = <M extends ModelName>(
 export const selectPayloadForModel = <M extends ModelName>(
   resource: M,
   options?: EditOptions<M> | ListOptions<M>,
-  level: "scalar" | "object" = "scalar"
+  level: "scalar" | "object" = "scalar",
+  context: "list" | "edit" = "edit"
 ) => {
   const model = getSchema().definitions[
     resource
@@ -753,7 +754,7 @@ export const selectPayloadForModel = <M extends ModelName>(
         !displayKeys
       ) {
         if (fieldNextAdmin?.kind === "object" && level === "object") {
-          if (fieldNextAdmin?.isList) {
+          if (fieldNextAdmin?.isList && context === "list") {
             const countFields = acc["_count"]?.select ?? {};
             acc["_count"] = {
               select: {
@@ -761,25 +762,26 @@ export const selectPayloadForModel = <M extends ModelName>(
                 [name]: true,
               },
             };
-          }
-          acc[name] = {
-            select: selectPayloadForModel(
-              fieldNextAdmin.type as ModelName,
-              {},
-              "scalar"
-            ),
-          };
-
-          const orderField =
-            (options as EditOptions<M>)?.fields?.[
-              name as Field<M>
-              // @ts-expect-error
-            ]?.orderField || (options as ListOptions<M>)?.orderField;
-
-          if (orderField) {
-            acc[name].orderBy = {
-              [orderField]: "asc",
+          } else {
+            acc[name] = {
+              select: selectPayloadForModel(
+                fieldNextAdmin.type as ModelName,
+                {},
+                "scalar"
+              ),
             };
+
+            const orderField =
+              (options as EditOptions<M>)?.fields?.[
+                name as Field<M>
+                // @ts-expect-error
+              ]?.orderField || (options as ListOptions<M>)?.orderField;
+
+            if (orderField) {
+              acc[name].orderBy = {
+                [orderField]: "asc",
+              };
+            }
           }
         } else {
           acc[name] = true;


### PR DESCRIPTION
## Title

Fix: avoid fetching list relation records in list view (N+1 query regression)

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Example update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Issue

- Closes: #635 
- Related: #593 (regression introduced by the fix)

## Description

When a model's `list.display` includes a list relation field (e.g. `Organization.list.display = ["users"]`), `selectPayloadForModel` was fetching all related records alongside the `_count` - even though only the count is ever rendered in the list view.

### History:
- #593 (`e14d6a4`) originally fixed this by putting `acc[name]` in the `else` block, so list relations only selected `_count`
- #608 (`fe5e1c3`) moved `acc[name]` outside the `else` to fix many-to-many default values on the edit form (#605), reintroducing the N+1

This fix adds a `context: "list" | "edit"` parameter (defaulting to `"edit"`) to `selectPayloadForModel`. The `isList` branch now only selects `_count` when `context === "list"`, and falls through to fetch full records otherwise. The edit path is unchanged — it never passes `"list"`, so many-to-many default values continue to work correctly.

## Screenshots

N/A

## Testing

Verified that:
- List views for models with list relation fields in `display` no longer fetch full related records
- Edit forms with many-to-many fields still populate default values correctly (the regression from #605 is preserved)

## Impact

Significant query performance improvement for list views that display list relation fields. Previously, every page load would fetch all related records for every row - now only counts are fetched, as intended.

## Additional Information

The `context` parameter defaults to `"edit"` to keep all existing call sites (including the recursive internal call) behaving as before. Only `preparePrismaListRequest` explicitly passes `"list"`.
